### PR TITLE
Two fixes

### DIFF
--- a/src/helpers/filterValidGroups.js
+++ b/src/helpers/filterValidGroups.js
@@ -1,6 +1,6 @@
 const uniqBy = require('lodash/uniqBy')
 
 const filterValidGroups = groups => {
-  return uniqBy(groups, 'gid').filter(({ structure, gid }) => gid && structure)
+  return uniqBy(groups, 'uuid').filter(({ structure, gid }) => gid && structure)
 }
 module.exports = filterValidGroups

--- a/src/helpers/filterValidGroups.spec.js
+++ b/src/helpers/filterValidGroups.spec.js
@@ -4,6 +4,7 @@ describe('filtering remote groups', () => {
   it('should remove groups with no id', () => {
     const groups = [
       {
+        uuid: '11111111-1A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1A',
@@ -15,12 +16,14 @@ describe('filtering remote groups', () => {
         ]
       },
       {
+        uuid: '11111111-',
         structure: '11111111',
         structureName: 'HOGWARTS',
         name: '2018-2019 2A',
         group_contacts: []
       },
       {
+        uuid: '11111111-',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: null,
@@ -32,6 +35,7 @@ describe('filtering remote groups', () => {
     const result = filterValidGroups(groups)
     expect(result).toEqual([
       {
+        uuid: '11111111-1A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1A',
@@ -45,9 +49,10 @@ describe('filtering remote groups', () => {
     ])
   })
 
-  it('should remove groups with duplicate ids', () => {
+  it('should remove groups with duplicate uuids', () => {
     const groups = [
       {
+        uuid: '11111111-1A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1A',
@@ -59,6 +64,7 @@ describe('filtering remote groups', () => {
         ]
       },
       {
+        uuid: '11111111-2A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '2A',
@@ -66,17 +72,31 @@ describe('filtering remote groups', () => {
         group_contacts: []
       },
       {
+        uuid: '11111111-2A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '2A',
         name: '2018-2019 2A DUPLICATE',
         group_contacts: []
+      },
+      {
+        uuid: '22222222-1A',
+        structure: '22222222',
+        structureName: 'HOGWARTS',
+        gid: '2A',
+        name: '2018-2019 2A',
+        group_contacts: [
+          { uuid: '1458-1523-1236-123' },
+          { uuid: '1452-1789-1236-456' },
+          { uuid: '1452-1598-3578-789' }
+        ]
       }
     ]
 
     const result = filterValidGroups(groups)
     expect(result).toEqual([
       {
+        uuid: '11111111-1A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1A',
@@ -88,11 +108,24 @@ describe('filtering remote groups', () => {
         ]
       },
       {
+        uuid: '11111111-2A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '2A',
         name: '2018-2019 2A',
         group_contacts: []
+      },
+      {
+        uuid: '22222222-1A',
+        structure: '22222222',
+        structureName: 'HOGWARTS',
+        gid: '2A',
+        name: '2018-2019 2A',
+        group_contacts: [
+          { uuid: '1458-1523-1236-123' },
+          { uuid: '1452-1789-1236-456' },
+          { uuid: '1452-1598-3578-789' }
+        ]
       }
     ])
   })

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -108,8 +108,8 @@ describe('synchronizing contacts', () => {
         fullname: 'Weasley Ronald',
         jobTitle: 'Élève',
         name: {
-          familyName: 'Ron', // Changed
-          givenName: 'Weasley'
+          familyName: 'Weasley',
+          givenName: 'Ron'
         },
         phone: [
           {
@@ -117,15 +117,106 @@ describe('synchronizing contacts', () => {
             primary: true
           }
         ]
+      },
+      {
+        _id: '307b3cdc9a855c549eb9d50a8bc93e6110594b25',
+        _rev: '2-20abd709a4cee2fc7855da2ad26c84ad0b2fac1d',
+        cozy: [],
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '7281-7189-0928-663',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-04-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          updatedByApps: [
+            {
+              date: '2019-04-12T15:40:08.126Z',
+              slug: 'Contacts',
+              version: '0.8.2'
+            },
+            {
+              date: '2019-04-12T14:34:29.088Z',
+              slug: 'konnector-toutatice',
+              version: '1.0.0'
+            }
+          ]
+        },
+        fullname: 'Hermione Granger',
+        jobTitle: 'Élève',
+        name: {
+          familyName: 'Granger',
+          givenName: 'Hermione'
+        }
+      },
+      {
+        _id: '10e5866050d20afe8ccae04456491db7908a96ec',
+        _rev: '2-cb79bd0ce2a8c435a9bbeddc9ef6c8bc7c3c4b43',
+        cozy: [
+          {
+            primary: false,
+            url: 'https://harry.theburrow.cloud'
+          },
+          {
+            primary: true,
+            url: 'https://potterstinks.mytoutatice.cloud'
+          }
+        ],
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '7617-0092-1667-282',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-04-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          updatedByApps: [
+            {
+              date: '2019-04-12T15:40:08.126Z',
+              slug: 'Contacts',
+              version: '0.8.2'
+            },
+            {
+              date: '2019-04-12T14:34:29.088Z',
+              slug: 'konnector-toutatice',
+              version: '1.0.0'
+            }
+          ]
+        },
+        fullname: 'Harry Potter',
+        jobTitle: 'Élève',
+        name: {
+          familyName: 'Potter',
+          givenName: 'Harry'
+        }
       }
     ]
     const remoteContacts = [
       {
         uuid: '1452-1598-3578-789',
-        firstname: 'Ronald',
+        firstname: 'Ronald', // changed
         lastname: 'Weasley',
         title: 'ele',
         cloud_url: 'rweasley12.mytoutatice.cloud'
+      },
+      {
+        uuid: '7281-7189-0928-663',
+        firstname: 'Hermione',
+        lastname: 'Granger',
+        title: 'ele',
+        cloud_url: 'hgranger14.mytoutatice.cloud' // added
+      },
+      {
+        uuid: '7617-0092-1667-282',
+        firstname: 'Harry',
+        lastname: 'Potter',
+        title: 'ele',
+        cloud_url: 'hpotter3.mytoutatice.cloud' // changed
       }
     ]
 
@@ -135,7 +226,8 @@ describe('synchronizing contacts', () => {
       remoteContacts,
       cozyContacts
     )
-    expect(mockCozyUtils.save).toHaveBeenCalledWith({
+    expect(mockCozyUtils.save).toHaveBeenCalledTimes(3)
+    expect(mockCozyUtils.save).toHaveBeenNthCalledWith(1, {
       _id: 'da30c4ca96ec5068874ae5fe9a005eb1',
       _rev: '2-c39d514f9b25a694a1331f893ba4bf2f',
       _type: 'io.cozy.contacts',
@@ -182,9 +274,92 @@ describe('synchronizing contacts', () => {
         }
       ]
     })
+    expect(mockCozyUtils.save).toHaveBeenNthCalledWith(2, {
+      _id: '307b3cdc9a855c549eb9d50a8bc93e6110594b25',
+      _rev: '2-20abd709a4cee2fc7855da2ad26c84ad0b2fac1d',
+      _type: 'io.cozy.contacts',
+      cozy: [
+        {
+          primary: true,
+          label: null,
+          url: 'https://hgranger14.mytoutatice.cloud'
+        }
+      ],
+      cozyMetadata: {
+        sync: {
+          [MOCK_CONTACT_ACCOUNT_ID]: {
+            contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+            id: '7281-7189-0928-663',
+            konnector: 'konnector-toutatice',
+            lastSync: MOCKED_DATE,
+            remoteRev: null
+          }
+        },
+        updatedByApps: [
+          {
+            date: '2019-04-12T15:40:08.126Z',
+            slug: 'Contacts',
+            version: '0.8.2'
+          },
+          {
+            date: '2019-04-12T14:34:29.088Z',
+            slug: 'konnector-toutatice',
+            version: '1.0.0'
+          }
+        ]
+      },
+      fullname: 'Hermione Granger',
+      jobTitle: 'Élève',
+      name: {
+        familyName: 'Granger',
+        givenName: 'Hermione'
+      }
+    })
+    expect(mockCozyUtils.save).toHaveBeenNthCalledWith(3, {
+      _id: '10e5866050d20afe8ccae04456491db7908a96ec',
+      _rev: '2-cb79bd0ce2a8c435a9bbeddc9ef6c8bc7c3c4b43',
+      _type: 'io.cozy.contacts',
+      cozy: [
+        {
+          label: null,
+          primary: true,
+          url: 'https://hpotter3.mytoutatice.cloud'
+        }
+      ],
+      cozyMetadata: {
+        sync: {
+          [MOCK_CONTACT_ACCOUNT_ID]: {
+            contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+            id: '7617-0092-1667-282',
+            konnector: 'konnector-toutatice',
+            lastSync: MOCKED_DATE,
+            remoteRev: null
+          }
+        },
+        updatedByApps: [
+          {
+            date: '2019-04-12T15:40:08.126Z',
+            slug: 'Contacts',
+            version: '0.8.2'
+          },
+          {
+            date: '2019-04-12T14:34:29.088Z',
+            slug: 'konnector-toutatice',
+            version: '1.0.0'
+          }
+        ]
+      },
+      fullname: 'Harry Potter',
+      jobTitle: 'Élève',
+      name: {
+        familyName: 'Potter',
+        givenName: 'Harry'
+      }
+    })
+
     expect(result.contacts).toEqual({
       created: 0,
-      updated: 1,
+      updated: 3,
       skipped: 0
     })
   })


### PR DESCRIPTION
The problem with groups was purely a business logic problem, we weren't filtering the correct field.

The problem with cozy urls was that `get(contact, 'cozy.url')` always returns `undefined` because the `cozy` field is an array. So no updates were ever performed, and once I corrected that, I found out some updates were trickier than others. I added the relevant tests, all should be good now.