### PR TITLE
fix: Untrash trashed contacts

### DIFF
--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -2,6 +2,7 @@ const get = require('lodash/get')
 const pLimit = require('p-limit')
 const mergeWith = require('lodash/mergeWith')
 const isArray = require('lodash/isArray')
+const unset = require('lodash/unset')
 const transpileContactToCozy = require('./helpers/transpileContactToCozy')
 
 const haveRemoteFieldsChanged = (
@@ -14,6 +15,7 @@ const haveRemoteFieldsChanged = (
     'name.givenName',
     'cozy.0.url',
     'jobTitle',
+    'trashed', // always false for the remote/next contact
     `cozyMetadata.sync.${contactAccountId}.id`
   ]
   return diffKeys.some(
@@ -71,6 +73,7 @@ const synchronizeContacts = async (
         transpiledContact,
         mergeWithCozyOverride
       )
+      unset(merged, 'trashed')
       cozyUtils.save(merged)
       result.contacts.updated++
     } else {

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -425,6 +425,115 @@ describe('synchronizing contacts', () => {
     })
   })
 
+  it('should untrash a trashed contact', async () => {
+    const cozyContacts = [
+      {
+        _id: 'a145b5551e46fe3870763109c90063f0',
+        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+        trashed: true,
+        cozy: [
+          {
+            label: null,
+            primary: true,
+            url: 'https://hgranger14.mytoutatice.cloud'
+          }
+        ],
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '7162-1889-0916-6273',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-04-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          updatedByApps: [
+            {
+              date: '2019-04-12T15:40:08.126Z',
+              slug: 'Contacts',
+              version: '0.8.2'
+            },
+            {
+              date: '2019-04-12T14:34:29.088Z',
+              slug: 'konnector-toutatice',
+              version: '1.0.0'
+            }
+          ]
+        },
+        fullname: 'Hermione Granger',
+        jobTitle: 'Élève',
+        name: {
+          familyName: 'Granger',
+          givenName: 'Hermione'
+        }
+      }
+    ]
+    const remoteContacts = [
+      {
+        uuid: '7162-1889-0916-6273',
+        firstname: 'Hermione',
+        lastname: 'Granger',
+        title: 'ele',
+        cloud_url: 'hgranger14.mytoutatice.cloud'
+      }
+    ]
+
+    const result = await synchronizeContacts(
+      mockCozyUtils,
+      MOCK_CONTACT_ACCOUNT_ID,
+      remoteContacts,
+      cozyContacts
+    )
+    expect(mockCozyUtils.save).toHaveBeenCalledTimes(1)
+    expect(mockCozyUtils.save).toHaveBeenCalledWith({
+      _id: 'a145b5551e46fe3870763109c90063f0',
+      _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+      _type: 'io.cozy.contacts',
+      cozy: [
+        {
+          label: null,
+          primary: true,
+          url: 'https://hgranger14.mytoutatice.cloud'
+        }
+      ],
+      cozyMetadata: {
+        sync: {
+          [MOCK_CONTACT_ACCOUNT_ID]: {
+            contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+            id: '7162-1889-0916-6273',
+            konnector: 'konnector-toutatice',
+            lastSync: MOCKED_DATE,
+            remoteRev: null
+          }
+        },
+        updatedByApps: [
+          {
+            date: '2019-04-12T15:40:08.126Z',
+            slug: 'Contacts',
+            version: '0.8.2'
+          },
+          {
+            date: '2019-04-12T14:34:29.088Z',
+            slug: 'konnector-toutatice',
+            version: '1.0.0'
+          }
+        ]
+      },
+      fullname: 'Hermione Granger',
+      jobTitle: 'Élève',
+      name: {
+        familyName: 'Granger',
+        givenName: 'Hermione'
+      }
+    })
+    expect(result.contacts).toEqual({
+      created: 0,
+      updated: 1,
+      skipped: 0
+    })
+  })
+
   it('should keep cozy fields when remote fields are missing', async () => {
     const cozyContacts = [
       {


### PR DESCRIPTION
Contacts that are linked to an account get `trashed` by the Contacts app, so that the connector can trash the remote version before deleting the contact.

However, with toutatice we don't trash remote contacts, rather we recreate them on the cozy… so here we just remove the `trashed` flag.