### PR TITLE
feat: Handle contact <-> group relationships

### DIFF
--- a/src/helpers/attachGroupsToContacts.js
+++ b/src/helpers/attachGroupsToContacts.js
@@ -1,0 +1,54 @@
+const get = require('lodash/get')
+const { log } = require('cozy-konnector-libs')
+
+const getRemoteGroupsForContact = (remoteGroups, contactId) => {
+  return remoteGroups.filter(remoteGroup => {
+    const groupContacts = get(remoteGroup, 'group_contacts', [])
+    return groupContacts.find(({ uuid }) => uuid === contactId)
+  })
+}
+
+const attachGroupsToContacts = (
+  contacts,
+  remoteGroups,
+  cozyGroups,
+  contactsAccountsId
+) => {
+  const cozyGroupsByRemoteId = cozyGroups.reduce((acc, cozyGroup) => {
+    const remoteId = get(
+      cozyGroup,
+      `cozyMetadata.sync.${contactsAccountsId}.id`
+    )
+
+    const matchingGroup = remoteGroups.find(({ uuid }) => remoteId === uuid)
+    if (matchingGroup) acc[matchingGroup.uuid] = cozyGroup
+    else {
+      log(
+        'warn',
+        `Unable to find a matching remote group for cozy group with id ${
+          cozyGroup._id
+        }`
+      )
+      log('warn', remoteGroups)
+    }
+    return acc
+  }, {})
+
+  return contacts.map(contact => {
+    const contactRemoteGroups = getRemoteGroupsForContact(
+      remoteGroups,
+      contact.uuid
+    )
+    const contactCozyGroups = contactRemoteGroups
+      .map(({ uuid }) => cozyGroupsByRemoteId[uuid])
+      .filter(cozyGroup => !!cozyGroup)
+
+    const contactWithGroups = {
+      ...contact,
+      groups: contactCozyGroups.map(group => ({ _id: get(group, '_id') }))
+    }
+    return contactWithGroups
+  })
+}
+
+module.exports = attachGroupsToContacts

--- a/src/helpers/attachGroupsToContacts.spec.js
+++ b/src/helpers/attachGroupsToContacts.spec.js
@@ -1,0 +1,198 @@
+const attachGroupsToContacts = require('./attachGroupsToContacts')
+const MOCK_CONTACT_ACCOUNT_ID = '123-abc'
+
+describe('attaching groups to contacts', () => {
+  it('should work', () => {
+    const contacts = [
+      {
+        uuid: '1',
+        firstname: 'Harry',
+        lastname: 'Potter'
+      },
+      {
+        uuid: '2',
+        firstname: 'Hermione',
+        lastname: 'Granger'
+      },
+      {
+        uuid: '3',
+        firstname: 'Draco',
+        lastname: 'Malfoy'
+      }
+    ]
+
+    const remoteGroups = [
+      {
+        uuid: 'HOGWARTS-GRF',
+        structure: 'HOGWARTS',
+        structureName: 'Hogwarts',
+        gid: 'GRF',
+        name: 'Gryffindor',
+        group_contacts: [{ uuid: '1' }, { uuid: '2' }]
+      },
+      {
+        uuid: 'HOGWARTS-SLT',
+        structure: 'HOGWARTS',
+        structureName: 'Hogwarts',
+        gid: 'SLT',
+        name: 'Slytherin',
+        group_contacts: [{ uuid: '3' }]
+      },
+      {
+        uuid: 'HOGWARTS-PTN',
+        structure: 'HOGWARTS',
+        structureName: 'Hogwarts',
+        gid: 'PTN',
+        name: 'Potion class',
+        group_contacts: [{ uuid: '1' }, { uuid: '2' }, { uuid: '3' }]
+      }
+    ]
+
+    const cozyGroups = [
+      {
+        _id: 'cozy-id-gryffindor',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              id: 'HOGWARTS-GRF',
+              konnector: 'konnector-toutatice'
+            }
+          }
+        }
+      },
+      {
+        _id: 'cozy-id-slytherin',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              id: 'HOGWARTS-SLT',
+              konnector: 'konnector-toutatice'
+            }
+          }
+        }
+      },
+      {
+        _id: 'cozy-id-potion',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              id: 'HOGWARTS-PTN',
+              konnector: 'konnector-toutatice'
+            }
+          }
+        }
+      }
+    ]
+
+    const result = attachGroupsToContacts(
+      contacts,
+      remoteGroups,
+      cozyGroups,
+      MOCK_CONTACT_ACCOUNT_ID
+    )
+    expect(result).toEqual([
+      {
+        uuid: '1',
+        firstname: 'Harry',
+        lastname: 'Potter',
+        groups: [
+          {
+            _id: 'cozy-id-gryffindor'
+          },
+          {
+            _id: 'cozy-id-potion'
+          }
+        ]
+      },
+      {
+        uuid: '2',
+        firstname: 'Hermione',
+        lastname: 'Granger',
+        groups: [
+          {
+            _id: 'cozy-id-gryffindor'
+          },
+          {
+            _id: 'cozy-id-potion'
+          }
+        ]
+      },
+      {
+        uuid: '3',
+        firstname: 'Draco',
+        lastname: 'Malfoy',
+        groups: [
+          {
+            _id: 'cozy-id-slytherin'
+          },
+          {
+            _id: 'cozy-id-potion'
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should not include a remote group with no matching cozy group', () => {
+    const contacts = [
+      {
+        uuid: '1',
+        firstname: 'Harry',
+        lastname: 'Potter'
+      }
+    ]
+
+    const remoteGroups = [
+      {
+        uuid: 'HOGWARTS-GRF',
+        structure: 'HOGWARTS',
+        structureName: 'Hogwarts',
+        gid: 'GRF',
+        name: 'Gryffindor',
+        group_contacts: [{ uuid: '1' }]
+      },
+      {
+        uuid: 'HOGWARTS-PTN',
+        structure: 'HOGWARTS',
+        structureName: 'Hogwarts',
+        gid: 'PTN',
+        name: 'Potion class',
+        group_contacts: [{ uuid: '1' }]
+      }
+    ]
+
+    const cozyGroups = [
+      {
+        _id: 'cozy-id-gryffindor',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              id: 'HOGWARTS-GRF',
+              konnector: 'konnector-toutatice'
+            }
+          }
+        }
+      }
+    ]
+
+    const result = attachGroupsToContacts(
+      contacts,
+      remoteGroups,
+      cozyGroups,
+      MOCK_CONTACT_ACCOUNT_ID
+    )
+    //expect a log
+    expect(result).toEqual([
+      {
+        uuid: '1',
+        firstname: 'Harry',
+        lastname: 'Potter',
+        groups: [
+          {
+            _id: 'cozy-id-gryffindor'
+          }
+        ]
+      }
+    ])
+  })
+})

--- a/src/helpers/filterValidContacts.spec.js
+++ b/src/helpers/filterValidContacts.spec.js
@@ -27,7 +27,7 @@ describe('filtering remote contacts', () => {
     })
   })
 
-  it('should discard conatcts with the same UUID', () => {
+  it('should discard contacts with the same UUID', () => {
     const source = [
       {
         uuid: '1458-1523-1236-123',

--- a/src/helpers/transpileContactToCozy.js
+++ b/src/helpers/transpileContactToCozy.js
@@ -32,6 +32,11 @@ const transpileContactToCozy = (contact, contactsAccountsId) => {
       ]
     : []
 
+  const groups = get(contact, 'groups', []).map(({ _id }) => ({
+    _id,
+    _type: 'io.cozy.contacts.groups'
+  }))
+
   return {
     _type: DOCTYPE_CONTACTS,
     name: {
@@ -40,6 +45,11 @@ const transpileContactToCozy = (contact, contactsAccountsId) => {
     },
     cozy,
     jobTitle,
+    relationships: {
+      groups: {
+        data: groups
+      }
+    },
     cozyMetadata: {
       sync: {
         [contactsAccountsId]: {

--- a/src/helpers/transpileContactToCozy.spec.js
+++ b/src/helpers/transpileContactToCozy.spec.js
@@ -21,7 +21,19 @@ describe('Transpile to cozy', () => {
       firstname: 'Harry',
       lastname: 'Potter',
       title: 'ele',
-      cloud_url: 'hpotter3.mytoutatice.cloud'
+      cloud_url: 'hpotter3.mytoutatice.cloud',
+      groups: [
+        {
+          _type: 'io.cozy.contacts.groups',
+          _id: 'd41d8cd98f00b204e9800998ecf8427e',
+          name: 'Gryffindor'
+        },
+        {
+          _type: 'io.cozy.contacts.groups',
+          _id: 'e284ce3c522873e4177454aad57dfcde',
+          name: 'Potion class'
+        }
+      ]
     }
     const result = transpileContactToCozy(source, MOCK_CONTACT_ACCOUNT_ID)
     expect(result).toEqual({
@@ -48,6 +60,20 @@ describe('Transpile to cozy', () => {
             remoteRev: null
           }
         }
+      },
+      relationships: {
+        groups: {
+          data: [
+            {
+              _id: 'd41d8cd98f00b204e9800998ecf8427e',
+              _type: 'io.cozy.contacts.groups'
+            },
+            {
+              _id: 'e284ce3c522873e4177454aad57dfcde',
+              _type: 'io.cozy.contacts.groups'
+            }
+          ]
+        }
       }
     })
   })
@@ -58,7 +84,14 @@ describe('Transpile to cozy', () => {
       firstname: 'Hermione',
       lastname: 'Granger',
       title: 'ens',
-      cloud_url: 'hgranger14.mytoutatice.cloud'
+      cloud_url: 'hgranger14.mytoutatice.cloud',
+      groups: [
+        {
+          _type: 'io.cozy.contacts.groups',
+          _id: 'd41d8cd98f00b204e9800998ecf8427e',
+          name: 'Gryffindor'
+        }
+      ]
     }
     const result = transpileContactToCozy(source, MOCK_CONTACT_ACCOUNT_ID)
     expect(result).toEqual({
@@ -84,6 +117,16 @@ describe('Transpile to cozy', () => {
             lastSync: MOCKED_DATE,
             remoteRev: null
           }
+        }
+      },
+      relationships: {
+        groups: {
+          data: [
+            {
+              _id: 'd41d8cd98f00b204e9800998ecf8427e',
+              _type: 'io.cozy.contacts.groups'
+            }
+          ]
         }
       }
     })
@@ -148,6 +191,11 @@ describe('Transpile to cozy', () => {
             lastSync: MOCKED_DATE,
             remoteRev: null
           }
+        }
+      },
+      relationships: {
+        groups: {
+          data: []
         }
       }
     })

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ async function start() {
     const filteredGroups = filterValidGroups(remoteGroups)
 
     const remoteGroupsId = filteredGroups.map(({ uuid }) => uuid)
-    const cozyGroups = await cozyUtils.findGroups(
+    const existingCozyGroups = await cozyUtils.findGroups(
       contactAccount._id,
       remoteGroupsId
     )
@@ -50,7 +50,7 @@ async function start() {
       cozyUtils,
       contactAccount._id,
       filteredGroups,
-      cozyGroups
+      existingCozyGroups
     )
     log('info', `${groupsSyncResult.created} groups created`)
     log('info', `${groupsSyncResult.updated} groups updated`)

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -31,7 +31,10 @@ const relationshipsMergeStrategy = connectorGroupIds => (
   const otherRelationships = omit(existingRelationships, 'groups')
   const existingGroups = get(existingRelationships, 'groups.data', [])
   const existingManualGroups = existingGroups.filter(
-    ({ _id }) => !connectorGroupIds.includes(_id)
+    ({ _id: existingGroupId }) =>
+      !connectorGroupIds.some(
+        ({ _id: connectorGroupId }) => connectorGroupId === existingGroupId
+      )
   )
   const newGroups = get(newRelationships, 'groups.data', [])
 

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -17,7 +17,7 @@ const customMerge = connectorGroupIds => (existingValue, newValue, key) => {
   else return undefined // for other fields, use the normal lodash merge strategy
 }
 
-// for the cozy field, we want to always the new value
+// for the cozy field, we always want to use the new value
 const cozyMergeStrategy = (existingCozy, newCozy) => {
   const hasNewCozyValue = isArray(newCozy) && newCozy.length > 0
   if (hasNewCozyValue) return newCozy
@@ -48,7 +48,7 @@ const relationshipsMergeStrategy = connectorGroupIds => (
 
 const getFinalContactData = (cozyContact, remoteContact, connectorGroupIds) => {
   const merged = mergeWith(
-    {},
+    {}, // we don't want to mutate cozyContact or remoteContact
     cozyContact,
     remoteContact,
     customMerge(connectorGroupIds)

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -6,21 +6,20 @@ const isEqual = require('lodash/isEqual')
 const unset = require('lodash/unset')
 const transpileContactToCozy = require('./helpers/transpileContactToCozy')
 
-// When merging contacts, we use the normal lodash merge function, except for the array of cozy URLs where we want a regular override
-const mergeWithCozyOverride = (objValue, srcValue, key) => {
-  const hasNewCozyValue =
-    key === 'cozy' && isArray(srcValue) && srcValue.length > 0
-  if (hasNewCozyValue) return srcValue
+const customMerge = (objValue, srcValue, key) => {
+  if (key === 'cozy') return cozyMergeStrategy(objValue, srcValue)
+  else return undefined // for othr fields, use the normal lodash merge strategy
+}
+
+// for the cozy field, we want to always the new value
+const cozyMergeStrategy = (objCozy, srcCozy) => {
+  const hasNewCozyValue = isArray(srcCozy) && srcCozy.length > 0
+  if (hasNewCozyValue) return srcCozy
   else return undefined
 }
 
 const getFinalContactData = (cozyContact, remoteContact) => {
-  const merged = mergeWith(
-    {},
-    cozyContact,
-    remoteContact,
-    mergeWithCozyOverride
-  )
+  const merged = mergeWith({}, cozyContact, remoteContact, customMerge)
   unset(merged, 'trashed')
   return merged
 }

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -2,6 +2,7 @@ const get = require('lodash/get')
 const pLimit = require('p-limit')
 const mergeWith = require('lodash/mergeWith')
 const isArray = require('lodash/isArray')
+const isEqual = require('lodash/isEqual')
 const unset = require('lodash/unset')
 const transpileContactToCozy = require('./helpers/transpileContactToCozy')
 
@@ -35,10 +36,11 @@ const haveRemoteFieldsChanged = (
     'cozy.0.url',
     'jobTitle',
     'trashed', // always false for the remote/next contact
-    `cozyMetadata.sync.${contactAccountId}.id`
+    `cozyMetadata.sync.${contactAccountId}.id`,
+    'relationships.groups.data'
   ]
   return diffKeys.some(
-    key => get(currentContact, key) !== get(nextContact, key)
+    key => !isEqual(get(currentContact, key), get(nextContact, key))
   )
 }
 

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -37,7 +37,7 @@ describe('synchronizing contacts', () => {
       }
     ]
     const cozyContacts = []
-    const remoteGroups = ['id-group-gryffindor']
+    const remoteGroups = [{ _id: 'id-group-gryffindor' }]
     const result = await synchronizeContacts(
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
@@ -279,11 +279,11 @@ describe('synchronizing contacts', () => {
       }
     ]
     const remoteGroups = [
-      'id-group-gryffindor',
-      'id-group-magic-chess',
-      'id-group-numerology',
-      'id-group-quidditch',
-      'id-group-removed'
+      { _id: 'id-group-gryffindor' },
+      { _id: 'id-group-magic-chess' },
+      { _id: 'id-group-numerology' },
+      { _id: 'id-group-quidditch' },
+      { _id: 'id-group-removed' }
     ]
 
     const result = await synchronizeContacts(
@@ -516,7 +516,7 @@ describe('synchronizing contacts', () => {
         ]
       }
     ]
-    const remoteGroups = ['new-group-id', 'previous-group-id']
+    const remoteGroups = [{ _id: 'new-group-id' }, { _id: 'previous-group-id' }]
 
     const result = await synchronizeContacts(
       mockCozyUtils,
@@ -632,7 +632,7 @@ describe('synchronizing contacts', () => {
         ]
       }
     ]
-    const remoteGroups = ['id-group']
+    const remoteGroups = [{ _id: 'id-group' }]
 
     const result = await synchronizeContacts(
       mockCozyUtils,

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -28,15 +28,22 @@ describe('synchronizing contacts', () => {
         firstname: 'Harry',
         lastname: 'Potter',
         title: 'ele',
-        cloud_url: 'hpotter3.mytoutatice.cloud'
+        cloud_url: 'hpotter3.mytoutatice.cloud',
+        groups: [
+          {
+            _id: 'id-group-gryffindor'
+          }
+        ]
       }
     ]
     const cozyContacts = []
+    const remoteGroups = ['id-group-gryffindor']
     const result = await synchronizeContacts(
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      remoteGroups
     )
     expect(mockCozyUtils.save).toHaveBeenCalledWith({
       _type: 'io.cozy.contacts',
@@ -65,7 +72,9 @@ describe('synchronizing contacts', () => {
       },
       relationships: {
         groups: {
-          data: []
+          data: [
+            { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' }
+          ]
         }
       }
     })
@@ -121,7 +130,16 @@ describe('synchronizing contacts', () => {
             number: '001122334455',
             primary: true
           }
-        ]
+        ],
+        relationships: {
+          groups: {
+            data: [
+              { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' },
+              { _id: 'id-group-removed', _type: 'io.cozy.contacts.groups' },
+              { _id: 'id-group-manual', _type: 'io.cozy.contacts.groups' }
+            ]
+          }
+        }
       },
       {
         _id: '307b3cdc9a855c549eb9d50a8bc93e6110594b25',
@@ -155,6 +173,13 @@ describe('synchronizing contacts', () => {
         name: {
           familyName: 'Granger',
           givenName: 'Hermione'
+        },
+        relationships: {
+          groups: {
+            data: [
+              { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' }
+            ]
+          }
         }
       },
       {
@@ -198,6 +223,14 @@ describe('synchronizing contacts', () => {
         name: {
           familyName: 'Potter',
           givenName: 'Harry'
+        },
+        relationships: {
+          groups: {
+            data: [
+              { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' },
+              { _id: 'id-group-magic-chess', _type: 'io.cozy.contacts.groups' }
+            ]
+          }
         }
       }
     ]
@@ -207,29 +240,58 @@ describe('synchronizing contacts', () => {
         firstname: 'Ronald', // changed
         lastname: 'Weasley',
         title: 'ele',
-        cloud_url: 'rweasley12.mytoutatice.cloud'
+        cloud_url: 'rweasley12.mytoutatice.cloud',
+        groups: [
+          {
+            _id: 'id-group-gryffindor'
+          }
+        ]
       },
       {
         uuid: '7281-7189-0928-663',
         firstname: 'Hermione',
         lastname: 'Granger',
         title: 'ele',
-        cloud_url: 'hgranger14.mytoutatice.cloud' // added
+        cloud_url: 'hgranger14.mytoutatice.cloud', // added
+        groups: [
+          {
+            _id: 'id-group-gryffindor'
+          },
+          {
+            _id: 'id-group-numerology' //added
+          }
+        ]
       },
       {
         uuid: '7617-0092-1667-282',
         firstname: 'Harry',
         lastname: 'Potter',
         title: 'ele',
-        cloud_url: 'hpotter3.mytoutatice.cloud' // changed
+        cloud_url: 'hpotter3.mytoutatice.cloud', // changed
+        groups: [
+          {
+            _id: 'id-group-gryffindor'
+          },
+          {
+            _id: 'id-group-quidditch' // changed
+          }
+        ]
       }
+    ]
+    const remoteGroups = [
+      'id-group-gryffindor',
+      'id-group-magic-chess',
+      'id-group-numerology',
+      'id-group-quidditch',
+      'id-group-removed'
     ]
 
     const result = await synchronizeContacts(
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      remoteGroups
     )
     expect(mockCozyUtils.save).toHaveBeenCalledTimes(3)
     expect(mockCozyUtils.save).toHaveBeenNthCalledWith(1, {
@@ -280,7 +342,10 @@ describe('synchronizing contacts', () => {
       ],
       relationships: {
         groups: {
-          data: []
+          data: [
+            { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' },
+            { _id: 'id-group-manual', _type: 'io.cozy.contacts.groups' }
+          ]
         }
       }
     })
@@ -326,7 +391,10 @@ describe('synchronizing contacts', () => {
       },
       relationships: {
         groups: {
-          data: []
+          data: [
+            { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' },
+            { _id: 'id-group-numerology', _type: 'io.cozy.contacts.groups' }
+          ]
         }
       }
     })
@@ -372,7 +440,10 @@ describe('synchronizing contacts', () => {
       },
       relationships: {
         groups: {
-          data: []
+          data: [
+            { _id: 'id-group-gryffindor', _type: 'io.cozy.contacts.groups' },
+            { _id: 'id-group-quidditch', _type: 'io.cozy.contacts.groups' }
+          ]
         }
       }
     })
@@ -445,12 +516,14 @@ describe('synchronizing contacts', () => {
         ]
       }
     ]
+    const remoteGroups = ['new-group-id', 'previous-group-id']
 
     const result = await synchronizeContacts(
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      remoteGroups
     )
     expect(mockCozyUtils.save).toHaveBeenCalledTimes(1)
     expect(mockCozyUtils.save).toHaveBeenCalledWith({
@@ -559,12 +632,14 @@ describe('synchronizing contacts', () => {
         ]
       }
     ]
+    const remoteGroups = ['id-group']
 
     const result = await synchronizeContacts(
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      remoteGroups
     )
     expect(mockCozyUtils.save).not.toHaveBeenCalled()
     expect(result.contacts).toEqual({
@@ -632,7 +707,8 @@ describe('synchronizing contacts', () => {
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      []
     )
     expect(mockCozyUtils.save).toHaveBeenCalledTimes(1)
     expect(mockCozyUtils.save).toHaveBeenCalledWith({
@@ -736,7 +812,8 @@ describe('synchronizing contacts', () => {
       mockCozyUtils,
       MOCK_CONTACT_ACCOUNT_ID,
       remoteContacts,
-      cozyContacts
+      cozyContacts,
+      []
     )
     expect(mockCozyUtils.save).toHaveBeenCalledWith({
       _id: 'a145b5551e46fe3870763109c9008c1c',

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -62,6 +62,11 @@ describe('synchronizing contacts', () => {
             remoteRev: null
           }
         }
+      },
+      relationships: {
+        groups: {
+          data: []
+        }
       }
     })
     expect(result.contacts).toEqual({
@@ -272,7 +277,12 @@ describe('synchronizing contacts', () => {
           number: '001122334455',
           primary: true
         }
-      ]
+      ],
+      relationships: {
+        groups: {
+          data: []
+        }
+      }
     })
     expect(mockCozyUtils.save).toHaveBeenNthCalledWith(2, {
       _id: '307b3cdc9a855c549eb9d50a8bc93e6110594b25',
@@ -313,6 +323,11 @@ describe('synchronizing contacts', () => {
       name: {
         familyName: 'Granger',
         givenName: 'Hermione'
+      },
+      relationships: {
+        groups: {
+          data: []
+        }
       }
     })
     expect(mockCozyUtils.save).toHaveBeenNthCalledWith(3, {
@@ -354,6 +369,11 @@ describe('synchronizing contacts', () => {
       name: {
         familyName: 'Potter',
         givenName: 'Harry'
+      },
+      relationships: {
+        groups: {
+          data: []
+        }
       }
     })
 
@@ -525,6 +545,11 @@ describe('synchronizing contacts', () => {
       name: {
         familyName: 'Granger',
         givenName: 'Hermione'
+      },
+      relationships: {
+        groups: {
+          data: []
+        }
       }
     })
     expect(result.contacts).toEqual({
@@ -617,6 +642,11 @@ describe('synchronizing contacts', () => {
       name: {
         familyName: 'Black',
         givenName: 'Sirius'
+      },
+      relationships: {
+        groups: {
+          data: []
+        }
       }
     })
     expect(result.contacts).toEqual({

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -384,6 +384,123 @@ describe('synchronizing contacts', () => {
     })
   })
 
+  it('should update a contact where only the groups have changed', async () => {
+    const cozyContacts = [
+      {
+        _id: 'a145b5551e46fe3870763109c90063f0',
+        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+        cozy: [
+          {
+            label: null,
+            primary: true,
+            url: 'https://hgranger14.mytoutatice.cloud'
+          }
+        ],
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '7162-1889-0916-6273',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-04-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          updatedByApps: [
+            {
+              date: '2019-04-12T14:34:29.088Z',
+              slug: 'konnector-toutatice',
+              version: '1.0.0'
+            }
+          ]
+        },
+        fullname: 'Hermione Granger',
+        jobTitle: 'Élève',
+        name: {
+          familyName: 'Granger',
+          givenName: 'Hermione'
+        },
+        relationships: {
+          groups: {
+            data: [
+              { _id: 'previous-group-id', _type: 'io.cozy.contacts.groups' }
+            ]
+          }
+        }
+      }
+    ]
+    const remoteContacts = [
+      {
+        uuid: '7162-1889-0916-6273',
+        firstname: 'Hermione',
+        lastname: 'Granger',
+        title: 'ele',
+        cloud_url: 'hgranger14.mytoutatice.cloud',
+        groups: [
+          {
+            _type: 'io.cozy.contacts.groups',
+            _id: 'new-group-id',
+            name: 'New group'
+          }
+        ]
+      }
+    ]
+
+    const result = await synchronizeContacts(
+      mockCozyUtils,
+      MOCK_CONTACT_ACCOUNT_ID,
+      remoteContacts,
+      cozyContacts
+    )
+    expect(mockCozyUtils.save).toHaveBeenCalledTimes(1)
+    expect(mockCozyUtils.save).toHaveBeenCalledWith({
+      _id: 'a145b5551e46fe3870763109c90063f0',
+      _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+      _type: 'io.cozy.contacts',
+      cozy: [
+        {
+          label: null,
+          primary: true,
+          url: 'https://hgranger14.mytoutatice.cloud'
+        }
+      ],
+      cozyMetadata: {
+        sync: {
+          [MOCK_CONTACT_ACCOUNT_ID]: {
+            contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+            id: '7162-1889-0916-6273',
+            konnector: 'konnector-toutatice',
+            lastSync: MOCKED_DATE,
+            remoteRev: null
+          }
+        },
+        updatedByApps: [
+          {
+            date: '2019-04-12T14:34:29.088Z',
+            slug: 'konnector-toutatice',
+            version: '1.0.0'
+          }
+        ]
+      },
+      fullname: 'Hermione Granger',
+      jobTitle: 'Élève',
+      name: {
+        familyName: 'Granger',
+        givenName: 'Hermione'
+      },
+      relationships: {
+        groups: {
+          data: [{ _id: 'new-group-id', _type: 'io.cozy.contacts.groups' }]
+        }
+      }
+    })
+    expect(result.contacts).toEqual({
+      created: 0,
+      updated: 1,
+      skipped: 0
+    })
+  })
+
   it('should not update unmodified contacts', async () => {
     const cozyContacts = [
       {
@@ -418,6 +535,11 @@ describe('synchronizing contacts', () => {
         name: {
           familyName: 'Granger',
           givenName: 'Hermione'
+        },
+        relationships: {
+          groups: {
+            data: [{ _id: 'id-group', _type: 'io.cozy.contacts.groups' }]
+          }
         }
       }
     ]
@@ -427,7 +549,14 @@ describe('synchronizing contacts', () => {
         firstname: 'Hermione',
         lastname: 'Granger',
         title: 'ele',
-        cloud_url: 'hgranger14.mytoutatice.cloud'
+        cloud_url: 'hgranger14.mytoutatice.cloud',
+        groups: [
+          {
+            _id: 'id-group',
+            _type: 'io.cozy.contacts.groups',
+            name: 'Some unchanged group'
+          }
+        ]
       }
     ]
 

--- a/src/synchronizeGroups.js
+++ b/src/synchronizeGroups.js
@@ -12,7 +12,8 @@ const synchronizeGroups = async (
   const result = {
     created: 0,
     updated: 0,
-    skipped: 0
+    skipped: 0,
+    groups: []
   }
   const promises = remoteGroups.map(remoteGroup => async () => {
     const transpiledGroup = transpileGroupToCozy(remoteGroup, contactAccountId)
@@ -27,14 +28,17 @@ const synchronizeGroups = async (
     const needsUpdate = cozyGroup && cozyGroup.name !== transpiledGroup.name
 
     if (!cozyGroup) {
-      cozyUtils.save(transpiledGroup)
+      const created = await cozyUtils.save(transpiledGroup)
+      result.groups.push(created.data)
       result.created++
     } else if (needsUpdate) {
       const merged = merge({}, cozyGroup, transpiledGroup)
-      cozyUtils.save(merged)
+      const updated = await cozyUtils.save(merged)
+      result.groups.push(updated.data)
       result.updated++
     } else {
       // the group already exists and there is nothing to update
+      result.groups.push(cozyGroup)
       result.skipped++
     }
   })


### PR DESCRIPTION
The goal of this PR is to sync the relationships between contacts and groups. 

Before, we were doing:

1. Sync groups
2. Sync contacts

Now, we do

1. Sync groups
2. Match the list of contacts for a group (contained in the remote group) with the corresponding *cozy group*
3. Build a list of all cozy groups managed by the connector
4. Sync contacts

In step 4, we want to update the contacts `relationships`. We do the following steps:

- keep all relationships that aren't groups
- keep all groups that are created by the user — we know which ones are created by the connector, so we can deduce which ones we should leave untouched
- add the new connector groups

I'd like to add some jsdoc because it's not clear what data structure the different functions expect. They are "documented" in the tests but I think a jsdoc would be helpful. Other than that the PR is ready!