### PR TITLE
fix: Fetch all contacts created by the connector

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -19,7 +19,7 @@ class CozyUtils {
   async prepareIndexes(contactAccountId) {
     await this.client
       .collection(DOCTYPE_CONTACTS)
-      .createIndex([`cozyMetadata.sync.${contactAccountId}.id`])
+      .createIndex([`cozyMetadata.sync.${contactAccountId}.contactsAccountsId`])
     await this.client
       .collection(DOCTYPE_CONTACTS_GROUPS)
       .createIndex([`cozyMetadata.sync.${contactAccountId}.id`])
@@ -29,24 +29,21 @@ class CozyUtils {
    * async findContacts - Finds contacts based on a list of remote ids
    *
    * @param  {string} accountId The io.cozy.contacts.account contacts should be linked to
-   * @param  {array} remoteIds
    * @returns {array}
    */
-  async findContacts(accountId, remoteIds) {
+  async findContacts(accountId) {
     const contactsCollection = this.client.collection(DOCTYPE_CONTACTS)
     const resp = await contactsCollection.find(
       {
         cozyMetadata: {
           sync: {
             [accountId]: {
-              id: {
-                $in: remoteIds
-              }
+              contactsAccountsId: accountId
             }
           }
         }
       },
-      { indexedFields: [`cozyMetadata.sync.${accountId}.id`] }
+      { indexedFields: [`cozyMetadata.sync.${accountId}.contactsAccountsId`] }
     )
 
     return get(resp, 'data')

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -60,6 +60,9 @@ describe('CozyUtils', () => {
         DOCTYPE_CONTACTS_GROUPS
       )
       expect(createIndexSpy).toHaveBeenCalledWith([
+        'cozyMetadata.sync.fakeAccountId.contactsAccountsId'
+      ])
+      expect(createIndexSpy).toHaveBeenCalledWith([
         'cozyMetadata.sync.fakeAccountId.id'
       ])
     })
@@ -67,42 +70,26 @@ describe('CozyUtils', () => {
 
   describe('findContacts', () => {
     it('should find the contacts that have the given remote ids', async () => {
-      const findSpy = jest.fn().mockResolvedValue({
-        data: [
-          {
-            id: 'my-awesome-contact'
-          },
-          {
-            id: 'my-less-awesome-contact'
-          }
-        ]
-      })
+      const findSpy = jest.fn()
       cozyUtils.client.collection = jest.fn(() => ({
         find: findSpy
       }))
-      const result = await cozyUtils.findContacts('fakeAccountId', [
-        '1234-5678-7269-0018',
-        '2716-9818-1176-2836'
-      ])
+      await cozyUtils.findContacts('fakeAccountId')
       expect(cozyUtils.client.collection).toHaveBeenCalledWith(DOCTYPE_CONTACTS)
       expect(findSpy).toHaveBeenCalledWith(
         {
           cozyMetadata: {
             sync: {
               fakeAccountId: {
-                id: {
-                  $in: ['1234-5678-7269-0018', '2716-9818-1176-2836']
-                }
+                contactsAccountsId: 'fakeAccountId'
               }
             }
           }
         },
-        { indexedFields: ['cozyMetadata.sync.fakeAccountId.id'] }
+        {
+          indexedFields: ['cozyMetadata.sync.fakeAccountId.contactsAccountsId']
+        }
       )
-      expect(result).toEqual([
-        { id: 'my-awesome-contact' },
-        { id: 'my-less-awesome-contact' }
-      ])
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,11 +80,7 @@ async function start(fields) {
       contactAccount._id
     )
 
-    const remoteContactsId = filteredContacts.map(({ uuid }) => uuid)
-    const cozyContacts = await cozyUtils.findContacts(
-      contactAccount._id,
-      remoteContactsId
-    )
+    const cozyContacts = await cozyUtils.findContacts(contactAccount._id)
 
     const contactsSyncResult = await synchronizeContacts(
       cozyUtils,


### PR DESCRIPTION
We want to compare the list of contacts *already on the cozy* with the list of contacts sent by the remote — but we were fetching contacts by their remote ids, so a contact deleted on the remote would never be found in the local contacts.