### PR TITLE
feat: Throttle network requests

### DIFF
--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -116,10 +116,10 @@ const synchronizeContacts = async (
     )
 
     if (!cozyContact) {
-      cozyUtils.save(finalContact)
+      await cozyUtils.save(finalContact)
       result.contacts.created++
     } else if (needsUpdate) {
-      cozyUtils.save(finalContact)
+      await cozyUtils.save(finalContact)
       result.contacts.updated++
     } else {
       // the contact already exists and there is nothing to update
@@ -138,7 +138,7 @@ const synchronizeContacts = async (
     )
   })
 
-  contactsDeletedOnRemote.map(contactDeletedOnRemote => {
+  contactsDeletedOnRemote.map(async contactDeletedOnRemote => {
     const onlyManualRelationships = relationshipsMergeStrategy(
       connectorGroupIds
     )(contactDeletedOnRemote.relationships, {})
@@ -148,7 +148,7 @@ const synchronizeContacts = async (
       relationships: onlyManualRelationships
     }
 
-    cozyUtils.save(contactWithoutConnectorGroups)
+    await cozyUtils.save(contactWithoutConnectorGroups)
     result.contacts.updated++
   })
 


### PR DESCRIPTION
Despite using `plimit`, we were not `await`ing the  result of network requests, so the network request was queued for later, and the function kept going. Basically, we were *queueing* network requests in batches of 50, instead of *executing* requests in batches.

The fix is trivial, the test not so much — the connector didn't crash or produced wrong results, it was just using too much memory. The best unit test I could come up with is time based, which isn't very good in tests — but the delays are very short so I think it's acceptable.