### PR TITLE
Handle empty content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,32 @@
-[Cozy][cozy] Toutatice
-=======================================
+# [Cozy][cozy] Toutatice
 
-What's Cozy?
-------------
+## What's Cozy?
 
 ![Cozy Logo](https://cdn.rawgit.com/cozy/cozy-guidelines/master/templates/cozy_logo_small.svg)
 
 [Cozy] is a personal data platform that brings all your web services in the same private space. With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
-What is this konnector about ?
-------------------------------
+## What is this konnector about ?
 
 This konnector interacts with the [Toutatice] platform.
 
 ### Run and test
 
-Create a `konnector-dev-config.json` file at the root with your test credentials :
+Create a `konnector-dev-config.json` file at the root with the URL of the Cozy :
 
 ```javascript
 {
-  "COZY_URL": "http://cozy.tools:8080",
-  "fields": {"login":"zuck.m@rk.fb", "password":"123456"}
+  "COZY_URL": "http://cozy.tools:8080"
 }
 ```
-Then :
+
+Then you will need a token to make requests to [Toutatice]. Make sure no server is listening on `cozy.tools:8080` then run `yarn token`.
+
+Finally, run the konnector:
 
 ```sh
-yarn
-yarn standalone
+yarn dev
 ```
-For running the konnector connected to a Cozy server and more details see [konnectors tutorial](https://docs.cozy.io/en/tutorials/konnector/)
 
 ### Real OAuth authentication
 
@@ -84,12 +81,11 @@ To have a better understanding of what happens, you may also need to activate de
 cozy-stack instances debug cozy.tools:8080 true
 ```
 
-License
--------
+## License
 
 Cozy Toutatice is developed by Cozy Cloud and distributed under the [AGPL v3 license][agpl-3.0].
 
-[cozy]: https://cozy.io "Cozy Cloud"
+[cozy]: https://cozy.io 'Cozy Cloud'
 [agpl-3.0]: https://www.gnu.org/licenses/agpl-3.0.html
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
 [forum]: https://forum.cozy.io/
@@ -101,4 +97,4 @@ Cozy Toutatice is developed by Cozy Cloud and distributed under the [AGPL v3 lic
 [yarn]: https://yarnpkg.com
 [travis]: https://travis-ci.org
 [contribute]: CONTRIBUTING.md
-[Toutatice]: https://www.toutatice.fr/portail
+[toutatice]: https://www.toutatice.fr/portail

--- a/src/helpers/attachGroupsToContacts.js
+++ b/src/helpers/attachGroupsToContacts.js
@@ -25,9 +25,7 @@ const attachGroupsToContacts = (
     else {
       log(
         'warn',
-        `Unable to find a matching remote group for cozy group with id ${
-          cozyGroup._id
-        }`
+        `Unable to find a matching remote group for cozy group with id ${cozyGroup._id}`
       )
       log('warn', remoteGroups)
     }

--- a/src/helpers/getAccessToken.js
+++ b/src/helpers/getAccessToken.js
@@ -11,9 +11,7 @@ function getAccessToken(environment) {
   } catch (err) {
     log(
       'error',
-      `Please provide proper COZY_CREDENTIALS environment variable. ${
-        process.env.COZY_CREDENTIALS
-      } is not OK`
+      `Please provide proper COZY_CREDENTIALS environment variable. ${process.env.COZY_CREDENTIALS} is not OK`
     )
 
     throw err

--- a/src/toutaticeClient.js
+++ b/src/toutaticeClient.js
@@ -25,8 +25,8 @@ class ToutaticeClient {
         }
       }
     )
-    const infos = await response.json()
-    return infos
+    if (response.status === 200) return response.json()
+    else return null
   }
 }
 

--- a/src/toutaticeClient.spec.js
+++ b/src/toutaticeClient.spec.js
@@ -1,5 +1,6 @@
 jest.mock('isomorphic-fetch', () => {
   return jest.fn(() => ({
+    status: 200,
     json: jest.fn().mockResolvedValue({
       response: 'ok'
     })
@@ -53,6 +54,18 @@ describe('toutatice client', () => {
     expect(url).toMatch(new RegExp(`/contacts/${MOCK_UUID}$`))
     expect(authHeader).toEqual(`Bearer ${MOCK_TOKEN}`)
     expect(result).toEqual({ response: 'ok' })
+  })
+
+  it('should handle empty responses when fetching remote contacts', async () => {
+    const MOCK_UUID = 'my-uuid'
+    const mockResponse = {
+      status: 204,
+      json: jest.fn().mockRejectedValue('Parse error')
+    }
+    fetch.mockResolvedValue(mockResponse)
+    const result = await client.getContacts(MOCK_UUID)
+    expect(result).toEqual(null)
+    expect(mockResponse.json).not.toHaveBeenCalled()
   })
 
   it('should URL encode UUIDs', async () => {


### PR DESCRIPTION
The remote server can sometimes reply with a `204 No Content` - in that case we can't decode the response in JSON. Instead here we return `null` — the next parts of the code know how to handle that.