### PR TITLE
Groups bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "travisDeployKey": "./bin/generate_travis_deploy_key"
   },
   "dependencies": {
-    "cozy-client": "22.3.0",
+    "cozy-client": "27.7.0",
     "cozy-konnector-libs": "4.45.0",
-    "node-fetch": "2.6.1",
     "jest": "26.6.3",
     "json-loader": "0.5.7",
     "lodash": "4.17.21",
+    "node-fetch": "2.6.1",
     "p-limit": "3.1.0"
   },
   "devDependencies": {

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -150,5 +150,4 @@ class CozyUtils {
     return this.client.save(params)
   }
 }
-
 module.exports = CozyUtils

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -77,21 +77,21 @@ class CozyUtils {
    * @param  {array} remoteIds
    * @returns {array}
    */
-  async findGroups(accountId, remoteIds) {
+  async findGroups(accountId) {
     const groupsCollection = this.client.collection(DOCTYPE_CONTACTS_GROUPS)
     const resp = await groupsCollection.find(
       {
         cozyMetadata: {
           sync: {
             [accountId]: {
-              id: {
-                $in: remoteIds
+              contactsAccountsId: {
+                $in: [accountId]
               }
             }
           }
         }
       },
-      { indexedFields: [`cozyMetadata.sync.${accountId}.id`] }
+      { indexedFields: [`cozyMetadata.sync.${accountId}.contactsAccountsId`] }
     )
 
     return get(resp, 'data')

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -176,14 +176,16 @@ describe('CozyUtils', () => {
           cozyMetadata: {
             sync: {
               fakeAccountId: {
-                id: {
-                  $in: ['6167-7728-0938-1661', '7273-7639-1773-8379']
+                contactsAccountsId: {
+                  $in: ['fakeAccountId']
                 }
               }
             }
           }
         },
-        { indexedFields: ['cozyMetadata.sync.fakeAccountId.id'] }
+        {
+          indexedFields: ['cozyMetadata.sync.fakeAccountId.contactsAccountsId']
+        }
       )
       expect(result).toEqual([{ id: 'hufflepuff' }, { id: 'gryffindor' }])
     })

--- a/src/helpers/convertStructuresToGroups.js
+++ b/src/helpers/convertStructuresToGroups.js
@@ -6,6 +6,8 @@ const convertStructuresToGroups = structures => {
     const structureName = get(structure, 'name')
     const structureGroups = get(structure, 'groups', [])
 
+    // uuid construction has been changed from gid to name of the group
+    // old uuid was `${structureId}-${structureGroup.gid}`
     structureGroups.forEach(structureGroup => {
       groups.push({
         uuid: `${structureId}-${structureGroup.name}`,

--- a/src/helpers/convertStructuresToGroups.js
+++ b/src/helpers/convertStructuresToGroups.js
@@ -8,7 +8,7 @@ const convertStructuresToGroups = structures => {
 
     structureGroups.forEach(structureGroup => {
       groups.push({
-        uuid: `${structureId}-${structureGroup.gid}`,
+        uuid: `${structureId}-${structureGroup.name}`,
         structure: structureId,
         structureName,
         ...structureGroup

--- a/src/helpers/convertStructuresToGroups.spec.js
+++ b/src/helpers/convertStructuresToGroups.spec.js
@@ -55,7 +55,7 @@ describe('Converting structures array to groups', () => {
     const result = convertStructuresToGroups(structures)
     expect(result).toEqual([
       {
-        uuid: '11111111-1A',
+        uuid: '11111111-2018-2019 1A',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1A',
@@ -67,7 +67,7 @@ describe('Converting structures array to groups', () => {
         ]
       },
       {
-        uuid: '11111111-1B',
+        uuid: '11111111-2018-2019 1B',
         structure: '11111111',
         structureName: 'HOGWARTS',
         gid: '1B',
@@ -79,7 +79,7 @@ describe('Converting structures array to groups', () => {
         ]
       },
       {
-        uuid: '22222222-2A',
+        uuid: '22222222-2018-2019 2A',
         structure: '22222222',
         structureName: 'BEAUXBATONS',
         gid: '2A',
@@ -91,7 +91,7 @@ describe('Converting structures array to groups', () => {
         ]
       },
       {
-        uuid: '22222222-2B',
+        uuid: '22222222-2018-2019 2B',
         structure: '22222222',
         structureName: 'BEAUXBATONS',
         gid: '2B',

--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,8 @@ async function start(fields) {
     const remoteGroups = convertStructuresToGroups(remoteStructures)
     const filteredGroups = filterValidGroups(remoteGroups)
 
-    const remoteGroupsId = filteredGroups.map(({ uuid }) => uuid)
-    const existingCozyGroups = await cozyUtils.findGroups(
-      contactAccount._id,
-      remoteGroupsId
-    )
+    const existingCozyGroups = await cozyUtils.findGroups(contactAccount._id)
+
     const {
       groups: allConnectorGroups,
       ...groupsSyncResult

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,10 @@ async function start(fields) {
     log('info', `${groupsSyncResult.skipped} groups skipped`)
 
     log('info', 'Syncing contacts')
+    // Acquiring contacts from API
     const remoteContacts = get(remoteData, 'contacts', [])
+    log('debug', `${remoteContacts.length} contacts receive from API`)
+    // Remove duplicate contacts with same uuid
     const filteredContacts = filterValidContacts(remoteContacts)
 
     const remoteContactsWithGroups = attachGroupsToContacts(
@@ -85,7 +88,7 @@ async function start(fields) {
       allConnectorGroups,
       contactAccount._id
     )
-
+    // Acquiring contacts from Cozy
     const cozyContacts = await cozyUtils.findContacts(contactAccount._id)
 
     const contactsSyncResult = await synchronizeContacts(

--- a/src/synchronizeGroups.js
+++ b/src/synchronizeGroups.js
@@ -20,7 +20,6 @@ const synchronizeGroups = async (
     const remoteIdKey = `cozyMetadata.sync.${contactAccountId}.id`
     const remoteId = get(transpiledGroup, remoteIdKey)
 
-
     const cozyGroup = cozyGroups.find(group => {
       const cozyRemoteId = get(group, remoteIdKey)
       return cozyRemoteId === remoteId
@@ -41,18 +40,18 @@ const synchronizeGroups = async (
         result.groups.push(created.data)
         result.created++
       } else {
-        //Update
+        // Update
         let updatedGroup = cozyGroupWithOldId
-        set(updatedGroup,
-            `cozyMetadata.sync.${contactAccountId}.id`,
-            remoteGroup.structure + '-' + remoteGroup.name
-           )
+        set(
+          updatedGroup,
+          `cozyMetadata.sync.${contactAccountId}.id`,
+          remoteGroup.structure + '-' + remoteGroup.name
+        )
         const updated = await cozyUtils.save(updatedGroup)
         result.groups.push(updated.data)
         result.updated++
       }
-    }
-    else if (!cozyGroup) {
+    } else if (!cozyGroup) {
       const created = await cozyUtils.save(transpiledGroup)
       result.groups.push(created.data)
       result.created++

--- a/src/synchronizeGroups.js
+++ b/src/synchronizeGroups.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get')
+const set = require('lodash/set')
 const transpileGroupToCozy = require('./helpers/transpileGroupToCozy')
 
 const synchronizeGroups = async (
@@ -14,16 +15,44 @@ const synchronizeGroups = async (
     groups: []
   }
   for (const remoteGroup of remoteGroups) {
+    const remoteOldId = remoteGroup.structure + '-' + remoteGroup.gid
     const transpiledGroup = transpileGroupToCozy(remoteGroup, contactAccountId)
     const remoteIdKey = `cozyMetadata.sync.${contactAccountId}.id`
     const remoteId = get(transpiledGroup, remoteIdKey)
+
 
     const cozyGroup = cozyGroups.find(group => {
       const cozyRemoteId = get(group, remoteIdKey)
       return cozyRemoteId === remoteId
     })
 
-    if (!cozyGroup) {
+    const cozyGroupWithOldId = cozyGroups.find(group => {
+      const cozyRemoteId = get(group, remoteIdKey)
+      return cozyRemoteId === remoteOldId
+    })
+
+    if (!cozyGroup && cozyGroupWithOldId) {
+      const creationDate = Date.parse(
+        get(cozyGroupWithOldId, 'cozyMetadata.createdAt')
+      )
+      // This date was especially choosen because of api opening the 13Sept2021
+      if (creationDate < Date.parse('2021-09-10')) {
+        const created = await cozyUtils.save(transpiledGroup)
+        result.groups.push(created.data)
+        result.created++
+      } else {
+        //Update
+        let updatedGroup = cozyGroupWithOldId
+        set(updatedGroup,
+            `cozyMetadata.sync.${contactAccountId}.id`,
+            remoteGroup.structure + '-' + remoteGroup.name
+           )
+        const updated = await cozyUtils.save(updatedGroup)
+        result.groups.push(updated.data)
+        result.updated++
+      }
+    }
+    else if (!cozyGroup) {
       const created = await cozyUtils.save(transpiledGroup)
       result.groups.push(created.data)
       result.created++

--- a/src/synchronizeGroups.spec.js
+++ b/src/synchronizeGroups.spec.js
@@ -245,4 +245,114 @@ describe('synchronizing groups', () => {
     expect(result.skipped).toEqual(2)
     expect(result.groups.length).toEqual(3)
   })
+
+  it('Group with old id exists and is created before 10Sept21, should create new', async () => {
+    const cozyGroups = [
+      {
+        _id: 'a145b5551e46fe3870763109c90063f0',
+        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+        name: 'groupFakeName',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '11111111-groupFakeGid',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-10-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          createdAt: '2021-09-09T15:10:46.448Z', // Created before 10Sept21
+        }
+      }
+    ]
+    const remoteGroups = [
+      {
+        uuid: '11111111-groupFakeName',
+        structure: '11111111',
+        structureName: 'HOGWARTS',
+        gid: 'groupFakeGid',
+        name: 'groupFakeName',
+        group_contacts: [
+          { uuid: '1458-1523-1236-123' },
+          { uuid: '1452-1598-3578-789' }
+        ]
+      }
+    ]
+
+    const result = await synchronizeGroups(
+      mockCozyUtils,
+      MOCK_CONTACT_ACCOUNT_ID,
+      remoteGroups,
+      cozyGroups
+    )
+    expect(mockCozyUtils.save).toHaveBeenCalled()
+    expect(result.created).toEqual(1)
+    expect(result.updated).toEqual(0)
+    expect(result.skipped).toEqual(0)
+  })
+
+  it('Group with old id exists and is created after 10Sept21, should change id', async () => {
+    const cozyGroups = [
+      {
+        _id: 'a145b5551e46fe3870763109c90063f0',
+        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+        name: 'groupFakeName',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '11111111-groupFakeGid',
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-10-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          createdAt: '2021-09-11T15:10:46.448Z', // Created before 10Sept21
+        }
+      }
+    ]
+    const remoteGroups = [
+      {
+        uuid: '11111111-groupFakeName',
+        structure: '11111111',
+        structureName: 'HOGWARTS',
+        gid: 'groupFakeGid',
+        name: 'groupFakeName',
+        group_contacts: [
+          { uuid: '1458-1523-1236-123' },
+          { uuid: '1452-1598-3578-789' }
+        ]
+      }
+    ]
+
+    const result = await synchronizeGroups(
+      mockCozyUtils,
+      MOCK_CONTACT_ACCOUNT_ID,
+      remoteGroups,
+      cozyGroups
+    )
+    expect(mockCozyUtils.save).toHaveBeenCalledWith(
+      {
+        _id: 'a145b5551e46fe3870763109c90063f0',
+        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+        name: 'groupFakeName',
+        cozyMetadata: {
+          sync: {
+            [MOCK_CONTACT_ACCOUNT_ID]: {
+              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+              id: '11111111-groupFakeName', // Note the change here
+              konnector: 'konnector-toutatice',
+              lastSync: '2019-10-12T14:34:28.737Z',
+              remoteRev: null
+            }
+          },
+          createdAt: '2021-09-11T15:10:46.448Z',
+        }
+      }
+    )
+    expect(result.created).toEqual(0)
+    expect(result.updated).toEqual(1)
+    expect(result.skipped).toEqual(0)
+  })
 })

--- a/src/synchronizeGroups.spec.js
+++ b/src/synchronizeGroups.spec.js
@@ -262,7 +262,7 @@ describe('synchronizing groups', () => {
               remoteRev: null
             }
           },
-          createdAt: '2021-09-09T15:10:46.448Z', // Created before 10Sept21
+          createdAt: '2021-09-09T15:10:46.448Z' // Created before 10Sept21
         }
       }
     ]
@@ -308,7 +308,7 @@ describe('synchronizing groups', () => {
               remoteRev: null
             }
           },
-          createdAt: '2021-09-11T15:10:46.448Z', // Created before 10Sept21
+          createdAt: '2021-09-11T15:10:46.448Z' // Created before 10Sept21
         }
       }
     ]
@@ -332,25 +332,23 @@ describe('synchronizing groups', () => {
       remoteGroups,
       cozyGroups
     )
-    expect(mockCozyUtils.save).toHaveBeenCalledWith(
-      {
-        _id: 'a145b5551e46fe3870763109c90063f0',
-        _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
-        name: 'groupFakeName',
-        cozyMetadata: {
-          sync: {
-            [MOCK_CONTACT_ACCOUNT_ID]: {
-              contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
-              id: '11111111-groupFakeName', // Note the change here
-              konnector: 'konnector-toutatice',
-              lastSync: '2019-10-12T14:34:28.737Z',
-              remoteRev: null
-            }
-          },
-          createdAt: '2021-09-11T15:10:46.448Z',
-        }
+    expect(mockCozyUtils.save).toHaveBeenCalledWith({
+      _id: 'a145b5551e46fe3870763109c90063f0',
+      _rev: '2-4b0ab8ed71794e03adfd632aecf44c24',
+      name: 'groupFakeName',
+      cozyMetadata: {
+        sync: {
+          [MOCK_CONTACT_ACCOUNT_ID]: {
+            contactsAccountsId: MOCK_CONTACT_ACCOUNT_ID,
+            id: '11111111-groupFakeName', // Note the change here
+            konnector: 'konnector-toutatice',
+            lastSync: '2019-10-12T14:34:28.737Z',
+            remoteRev: null
+          }
+        },
+        createdAt: '2021-09-11T15:10:46.448Z'
       }
-    )
+    })
     expect(result.created).toEqual(0)
     expect(result.updated).toEqual(1)
     expect(result.skipped).toEqual(0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,18 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+array.prototype.foreach@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.foreach/-/array.prototype.foreach-1.0.2.tgz#592b177c8d6abb84e14de1649eb6e7cc5eb9c9ae"
+  integrity sha512-gCOgyBKIaFL5hekfQLhsNmF0TY4Y5JdtOyFKtbSpL72oiCAZ9Zi7TFvcfSsM1LnBFMog1RYVJF0PHgtnY+U5nA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    es-array-method-boxes-properly "^1.0.0"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -1885,30 +1897,6 @@ cozy-client-js@^0.19.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@22.3.0:
-  version "22.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-22.3.0.tgz#bdb7cce6b7463975c1d15147586aa5e3d17b9213"
-  integrity sha512-1g/CSykXqS3613WJOfyc21qUYEogkADHc6PN0mrhYnYhn/rYe4EPuRU+DQOZrhEQVy6tBusHPg9En3a77uBwgQ==
-  dependencies:
-    "@cozy/minilog" "1.0.0"
-    "@types/jest" "^26.0.20"
-    btoa "^1.2.1"
-    cozy-device-helper "^1.12.0"
-    cozy-flags "2.7.1"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^22.3.0"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    node-fetch "^2.6.1"
-    open "^7.0.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "3 || 4"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^7.0.0"
-
 cozy-client@23.4.0:
   version "23.4.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-23.4.0.tgz#edb310971939f61506baef5f29a1a1806d39aae9"
@@ -1932,6 +1920,33 @@ cozy-client@23.4.0:
     server-destroy "^1.0.1"
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
+
+cozy-client@27.7.0:
+  version "27.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.7.0.tgz#507663c671ff677a1b0a43e956cb053ab03803cb"
+  integrity sha512-3p6DRsa9VGnSjWiusMwhcmOEbCUikzMUPPQOWI3KJ4fcUBNU2ekjMzdygXr5+nlU4Dcg48hNFClC9bk2NcZ1QA==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.12.0"
+    cozy-flags "2.7.1"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^27.6.5"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
 
 cozy-client@^23.18.0:
   version "23.22.0"
@@ -2056,16 +2071,6 @@ cozy-logger@1.7.0, cozy-logger@^1.6.0, cozy-logger@^1.7.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^22.3.0:
-  version "22.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-22.3.0.tgz#92fd2ed915e911fd3b3319ee910591e43debc86a"
-  integrity sha512-B24JhHUEQAwk1AvJUG6z3I0EbIdyh68qBF/r9c8JzUO9DWFIFJdCqBycL6ToLgccwI3ZheX5lQwHYYGHw3zXzw==
-  dependencies:
-    cozy-flags "2.7.1"
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
 cozy-stack-client@^23.19.0:
   version "23.19.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-23.19.0.tgz#2972c3dcc151b13c0f65749f341a6349170fe1d3"
@@ -2080,6 +2085,16 @@ cozy-stack-client@^23.4.0:
   version "23.10.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-23.10.0.tgz#390d10ba3d43e343570c9ba3c9c0970d8805d373"
   integrity sha512-X+iXI9Ig5AxbLRxovvCwpAPmV8bf6pu84bpW5YnRo97M+THzU0pNZwQu+ss1iVlY5qez9VjOSKpWbISjICSegw==
+  dependencies:
+    cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^27.6.5:
+  version "27.6.5"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.6.5.tgz#4b40ad59821b957f161a77132b5346e99be0bc2c"
+  integrity sha512-aGkchVfvVGfI38qt+R8/BKv8nFN6Ihhx1LFsDYDtV+mW6OxOqVYdd22sIg9iHkusaqJgxgkMYnB9NcnDlC8Ajg==
   dependencies:
     cozy-flags "2.7.1"
     detect-node "^2.0.4"
@@ -2539,6 +2554,37 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.0"
+
+es-abstract@^1.19.0, es-abstract@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
 es-module-lexer@^0.9.0:
   version "0.9.3"
@@ -3219,7 +3265,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -3256,6 +3302,14 @@ get-stream@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
   integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -3348,7 +3402,7 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
-has-bigints@^1.0.0:
+has-bigints@^1.0.0, has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
@@ -3367,6 +3421,13 @@ has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -3621,6 +3682,15 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
@@ -3676,6 +3746,11 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
+
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -3819,6 +3894,19 @@ is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -3834,6 +3922,13 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -3845,6 +3940,13 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-weakref@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-whitespace@^0.3.0:
   version "0.3.0"
@@ -4545,7 +4647,7 @@ lodash@4, lodash@4.17.21, lodash@^4.14.2, lodash@^4.17.11, lodash@^4.17.12, loda
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4905,6 +5007,17 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
+node-polyglot@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.4.2.tgz#e4876e6710b70dc00b1351a9a68de4af47a5d61d"
+  integrity sha512-AgTVpQ32BQ5XPI+tFHJ9bCYxWwSLvtmEodX8ooftFhEuyCgBG6ijWulIVb7pH3THigtgvc9uLiPn0IO51KHpkg==
+  dependencies:
+    array.prototype.foreach "^1.0.0"
+    has "^1.0.3"
+    object.entries "^1.1.4"
+    string.prototype.trim "^1.2.4"
+    warning "^4.0.3"
+
 node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
@@ -4991,6 +5104,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.11.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
 object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
@@ -5027,6 +5145,15 @@ object.entries@^1.1.0:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
+
+object.entries@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.5.tgz#e1acdd17c4de2cd96d5a08487cfb9db84d881861"
+  integrity sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 object.fromentries@^2.0.0:
   version "2.0.4"
@@ -5097,6 +5224,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@7.4.2, open@^7.0.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 open@8.2.1:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/open/-/open-8.2.1.tgz#82de42da0ccbf429bc12d099dad2e0975e14e8af"
@@ -5105,14 +5240,6 @@ open@8.2.1:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-open@^7.0.2:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
-  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  dependencies:
-    is-docker "^2.0.0"
-    is-wsl "^2.1.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.3"
@@ -6103,6 +6230,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 sift@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/sift/-/sift-6.0.0.tgz#f93a778e5cbf05a5024ebc391e6b32511a6d1f82"
@@ -6357,6 +6493,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string.prototype.trim@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.5.tgz#a587bcc8bfad8cb9829a577f5de30dd170c1682c"
+  integrity sha512-Lnh17webJVsD6ECeovpVN17RlAKjmz4rF9S+8Y45CkMc/ufVpTkU3vZIyIC7sllQ1FCvObZnnCdNs/HXTUOTlg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
@@ -6766,6 +6911,16 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.0"
     which-boxed-primitive "^1.0.1"
 
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -6823,6 +6978,11 @@ url-search-params-polyfill@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz#b900cd9a0d9d2ff757d500135256f2344879cbff"
   integrity sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ==
+
+url-search-params-polyfill@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
+  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
 
 use@^3.1.0:
   version "3.1.1"
@@ -6955,6 +7115,13 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watchpack@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
@@ -7064,7 +7231,7 @@ whatwg-url@^8.5.0:
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
 
-which-boxed-primitive@^1.0.1:
+which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==


### PR DESCRIPTION
The construction of group id is now based on structure-name
The name must be unique.
To deal with existent data, group created before 10 sept 2021 will be untouch, and a new group will be created.
Group created after this date, will be updated with a new coherent unique id in their metadata