### PR TITLE
feat: Add dynamic link for apps fetching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,8 @@ async function start(fields) {
       destinationFolder
     )
     log('info', 'Creating shortcuts for school apps')
+    // For both of the following saveFiles we force validateFile to true
+    // in order to avoid "BAD_MIME_TYPE" error while saving the shortcuts
     await this.saveFiles(
       computedShortcuts.schoolShortcuts,
       { folderPath: destinationFolderPath },
@@ -126,7 +128,7 @@ async function start(fields) {
         sourceAccount: 'Toutatice',
         sourceAccountIdentifier: 'Toutatice',
         fileIdAttributes: ['vendorRef'],
-        validateFile: true,
+        validateFile: () => true,
         subPath: "/Applications de l'école"
       }
     )
@@ -139,7 +141,7 @@ async function start(fields) {
         sourceAccount: 'Toutatice',
         sourceAccountIdentifier: 'Toutatice',
         fileIdAttributes: ['vendorRef'],
-        validateFile: true
+        validateFile: () => true
       }
     )
 

--- a/src/toutaticeClient.js
+++ b/src/toutaticeClient.js
@@ -33,7 +33,7 @@ class ToutaticeClient {
   async getApps(uuid) {
     const encodedUuid = encodeURIComponent(uuid)
     const response = await fetch(
-      `https://partenaires.ipanema.education.fr/safran/api/v1/catalogues/${encodedUuid}/sync`,
+      `${this.url}/safran/api/v1/catalogues/${encodedUuid}/sync`,
       {
         method: 'POST',
         headers: {
@@ -58,7 +58,7 @@ class ToutaticeClient {
     await this.sleep(1000)
 
     const syncApps = await fetch(
-      `https://partenaires.ipanema.education.fr/safran/api/v1/catalogues/${encodedUuid}/applications`,
+      `${this.url}/safran/api/v1/catalogues/${encodedUuid}/applications`,
       {
         headers: {
           Authorization: `Bearer ${this.token}`


### PR DESCRIPTION
This PR replaces the hardcoded link use to fetch the list of apps by a dynamic one, so it work on int and prod environment and force validateFile to return true in order to avoid MimeType errors in saveFiles.