### PR TITLE
[SCR-593 SCR-596]Feat/home settings doctype

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,8 +9,7 @@
   "editor": "Cozy",
   "vendor_link": "https://www.toutatice.fr",
   "categories": [
-    "online_services",
-    "contacts"
+    "online_services"
   ],
   "fields": {
     "access_token": {
@@ -54,6 +53,12 @@
     "contactsAccounts": {
       "type": "io.cozy.contacts.accounts",
       "verbs": [
+        "ALL"
+      ]
+    },
+    "settings":{
+      "type": "io.cozy.home.settings",
+      "verbs":[
         "ALL"
       ]
     }

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -162,53 +162,59 @@ class CozyUtils {
     for (const file of files) {
       if (file.hubMetadata.favori) {
         const appToSave = {
-          ...file,
           vendorRef: file.hubMetadata.idInterne,
           filename: `${file.title}.url`,
           filestream: `[InternetShortcut]\nURL=${file.url}`,
-          shouldReplaceFile: true
-        }
-        if (
-          appToSave.icon &&
-          (appToSave.icon.startsWith('https://') ||
-            appToSave.icon.startsWith('http://'))
-        ) {
-          const finalIcon = await this.fetchIcon(appToSave.icon)
-          appToSave.fileAttributes = {
+          shouldReplaceFile: () => true,
+          fileAttributes: {
             metadata: {
-              icon: finalIcon.content,
-              iconMimeType: finalIcon.mimetype
+              ...file
             }
           }
-          delete appToSave.icon
+        }
+        if (
+          appToSave.fileAttributes.metadata.icon &&
+          (appToSave.fileAttributes.metadata.icon.startsWith('https://') ||
+            appToSave.fileAttributes.metadata.icon.startsWith('http://'))
+        ) {
+          const finalIcon = await this.fetchIcon(
+            appToSave.fileAttributes.metadata.icon
+          )
+          appToSave.fileAttributes.metadata.icon = finalIcon.content
+          appToSave.fileAttributes.metadata.iconMimeType = finalIcon.mimetype
           processedIcons++
         } else {
+          // If not usable, make sure to delete it to avoid bad display of the icon on cozy home
+          delete appToSave.fileAttributes.metadata.icon
           unprocessedIcons++
         }
         favShortcuts.push(appToSave)
       } else {
         const appToSave = {
-          ...file,
           vendorRef: file.hubMetadata.idInterne,
           filename: `${file.title}.url`,
           filestream: `[InternetShortcut]\nURL=${file.url}`,
-          shouldReplaceFile: true
-        }
-        if (
-          appToSave.icon &&
-          (appToSave.icon.startsWith('https://') ||
-            appToSave.icon.startsWith('http://'))
-        ) {
-          const finalIcon = await this.fetchIcon(appToSave.icon)
-          appToSave.fileAttributes = {
+          shouldReplaceFile: () => true,
+          fileAttributes: {
             metadata: {
-              icon: finalIcon.content,
-              iconMimeType: finalIcon.mimetype
+              ...file
             }
           }
-          delete appToSave.icon
+        }
+        if (
+          appToSave.fileAttributes.metadata.icon &&
+          (appToSave.fileAttributes.metadata.icon.startsWith('https://') ||
+            appToSave.fileAttributes.metadata.icon.startsWith('http://'))
+        ) {
+          const finalIcon = await this.fetchIcon(
+            appToSave.fileAttributes.metadata.icon
+          )
+          appToSave.fileAttributes.metadata.icon = finalIcon.content
+          appToSave.fileAttributes.metadata.iconMimeType = finalIcon.mimetype
           processedIcons++
         } else {
+          // If not usable, make sure to delete it to avoid bad display of the icon on cozy home
+          delete appToSave.fileAttributes.metadata.icon
           unprocessedIcons++
         }
         schoolShortcuts.push(appToSave)
@@ -253,7 +259,7 @@ class CozyUtils {
       let idx = allComputedShortcuts.findIndex(apiShortcut => {
         return (
           apiShortcut.vendorRef === cozyShortcut.metadata.fileIdAttributes &&
-          apiShortcut.hubMetadata.favori === isFavourite
+          apiShortcut.fileAttributes.metadata.hubMetadata.favori === isFavourite
         )
       })
       if (idx == -1) {

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -247,6 +247,7 @@ class CozyUtils {
       'debug',
       `${processedIcons} icons treated & ${unprocessedIcons} icons untreated : No valid urls`
     )
+
     return {
       schoolShortcuts,
       favShortcuts,
@@ -355,21 +356,39 @@ class CozyUtils {
         log('info', 'Store folder detected, skipping it')
         continue
       }
-      const favFolderLayout = {
-        id: oneFolder._id,
-        originalName: oneFolder.attributes.name,
-        createdByApp: 'toutatice',
-        mobile: {
-          detailedLines: true,
-          grouped: false
-        },
-        desktop: {
-          detailedLines: true,
-          grouped: false
-        },
-        order
+      if (oneFolder.attributes.name === 'Applications Toutatice') {
+        const favFolderLayout = {
+          id: oneFolder._id,
+          originalName: oneFolder.attributes.name,
+          createdByApp: 'toutatice',
+          mobile: {
+            detailedLines: true,
+            grouped: false
+          },
+          desktop: {
+            detailedLines: true,
+            grouped: false
+          },
+          order
+        }
+        sectionLayout.push(favFolderLayout)
+      } else {
+        const favFolderLayout = {
+          id: oneFolder._id,
+          originalName: oneFolder.attributes.name,
+          createdByApp: 'toutatice',
+          mobile: {
+            detailedLines: false,
+            grouped: true
+          },
+          desktop: {
+            detailedLines: false,
+            grouped: true
+          },
+          order
+        }
+        sectionLayout.push(favFolderLayout)
       }
-      sectionLayout.push(favFolderLayout)
       order++
     }
 

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -161,6 +161,7 @@ class CozyUtils {
     let infosShortcuts = []
     let spacesShortcuts = []
     let persoShortcuts = []
+    let rightContentStore = []
     let processedIcons = 0
     let unprocessedIcons = 0
     for (const file of files) {
@@ -193,23 +194,16 @@ class CozyUtils {
           delete appToSave.fileAttributes.metadata.icon
           unprocessedIcons++
         }
-        switch (appToSave.fileAttributes.metadata.type) {
-          case 'info':
-            log('info', 'Info shortcut')
-            infosShortcuts.push(appToSave)
-            break
-          case 'espace':
-            log('info', 'space shortcut')
-            spacesShortcuts.push(appToSave)
-            break
-          case 'perso':
-            log('info', 'perso shortcut')
-            persoShortcuts.push(appToSave)
-            break
-          // default here is for type "app" and other possible unknown types
-          default:
-            log('info', 'default (app) shortcut')
+        switch (appToSave.fileAttributes.metadata.source) {
+          case 'Toutatice':
+          case 'ENT':
+          case 'GAR':
+          case 'Arena':
             favShortcuts.push(appToSave)
+            break
+          // default here goes to contentStore, as if its not one of the above, it is all treated the same
+          default:
+            rightContentStore.push(appToSave)
             break
         }
       } else {
@@ -241,6 +235,28 @@ class CozyUtils {
           unprocessedIcons++
         }
         schoolShortcuts.push(appToSave)
+      }
+    }
+    for (const app of rightContentStore) {
+      switch (app.fileAttributes.metadata.type) {
+        case 'info':
+          log('info', 'Info shortcut')
+          infosShortcuts.push(app)
+          break
+        case 'triskell':
+        case 'perso':
+          log('info', 'Space shortcut')
+          spacesShortcuts.push(app)
+          break
+        case 'lien':
+          log('info', 'Perso shortcut')
+          persoShortcuts.push(app)
+          break
+        // fallback to fav folder if type is unknown
+        default:
+          log('info', 'Default (fav + unknown type) shortcut')
+          favShortcuts.push(app)
+          break
       }
     }
     log(

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -9,7 +9,8 @@ const {
   DOCTYPE_CONTACTS,
   DOCTYPE_CONTACTS_GROUPS,
   DOCTYPE_CONTACTS_ACCOUNT,
-  DOCTYPE_FILES
+  DOCTYPE_FILES,
+  DOCTYPE_HOME_SETTINGS
 } = require('./constants')
 class CozyUtils {
   constructor() {
@@ -299,6 +300,41 @@ class CozyUtils {
       )
       log('warn', err)
     }
+  }
+
+  async findOrCreateHomeSettingsDoctype(shortcuts) {
+    log('info', 'findOrCreateHomeSettingsDoctype starts')
+    let sectionLayout = []
+    let layout = {}
+    let order = 1
+    for (const shortcut of shortcuts) {
+      const shortcutLayout = {
+        id: shortcut.dir_id,
+        originalName: 'Applications Toutatice',
+        createdByApp: 'toutatice',
+        mobile: {
+          detailedLines: true,
+          grouped: false
+        },
+        desktop: {
+          detaileLines: true,
+          grouped: false
+        },
+        order
+      }
+      sectionLayout.push(shortcutLayout)
+      order++
+    }
+    layout.sectionLayout = sectionLayout
+    const { data: existingLayout } = await this.client.query(
+      Q(DOCTYPE_HOME_SETTINGS).getById('layout')
+    )
+    if (existingLayout) {
+      layout = { ...existingLayout, ...layout }
+    } else {
+      layout = { ...layout, id: 'laytout', _type: DOCTYPE_HOME_SETTINGS }
+    }
+    await this.client.save(layout)
   }
 
   getIconizerUrl() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ module.exports = {
   DOCTYPE_ACCOUNT: 'io.cozy.accounts',
   DOCTYPE_TRIGGERS: 'io.cozy.triggers',
   DOCTYPE_FILES: 'io.cozy.files',
+  DOCTYPE_HOME_SETTINGS: 'io.cozy.home.settings',
   DOCTYPE_CONTACTS_VERSION: 2,
   DOCTYPE_CONTACTS_GROUPS_VERSION: 2,
   DOCTYPE_CONTACTS_ACCOUNT_VERSION: 1,

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -282,13 +282,32 @@ describe('CozyUtils', () => {
       const foundShortcuts = []
       const computedShortcuts = {
         schoolShortcuts: [],
-        favShortcuts: []
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const folder = {
+      const destinationStoreFolder = {
         _id: 'SOME_DIR_ID'
       }
-      const favFolder = {
+      const destinationFavFolder = {
         _id: 'SOME_FAV_DIR_ID'
+      }
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
       }
       const deleteFilePermanentlySpy = jest.fn()
       cozyUtils.client.collection = jest.fn(() => ({
@@ -298,8 +317,7 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
       )
       expect(deleteFilePermanentlySpy).not.toHaveBeenCalled()
     })
@@ -319,13 +337,32 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE'
           }
         ],
-        favShortcuts: []
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const favFolder = {
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
         _id: 'SOME_FAV_DIR_ID'
       }
-      const folder = {
-        _id: 'SOME_DIR_ID'
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
       }
 
       const deleteFilePermanentlySpy = jest.fn()
@@ -336,8 +373,7 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
       )
       expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
     })
@@ -371,13 +407,32 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE'
           }
         ],
-        favShortcuts: []
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const favFolder = {
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
         _id: 'SOME_FAV_DIR_ID'
       }
-      const folder = {
-        _id: 'SOME_DIR_ID'
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
       }
 
       const deleteFilePermanentlySpy = jest.fn()
@@ -388,8 +443,7 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
       )
       expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(3)
       expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
@@ -424,24 +478,51 @@ describe('CozyUtils', () => {
         schoolShortcuts: [
           {
             vendorRef: 'SOME_OTHER_VALUE',
-            hubMetadata: {
-              favori: false
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
             }
           },
           {
             vendorRef: 'SOME_VALUE_2',
-            hubMetadata: {
-              favori: false
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
             }
           }
         ],
-        favShortcuts: []
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const favFolder = {
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
         _id: 'SOME_FAV_DIR_ID'
       }
-      const folder = {
-        _id: 'SOME_DIR_ID'
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
       }
 
       const deleteFilePermanentlySpy = jest.fn()
@@ -452,8 +533,7 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
       )
       expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
       expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
@@ -490,25 +570,52 @@ describe('CozyUtils', () => {
         schoolShortcuts: [
           {
             vendorRef: 'SOME_OTHER_VALUE',
-            hubMetadata: {
-              favori: false
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
             }
           }
         ],
         favShortcuts: [
           {
             vendorRef: 'SOME_VALUE_2',
-            hubMetadata: {
-              favori: true
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: true
+                }
+              }
             }
           }
-        ]
+        ],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const favFolder = {
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
         _id: 'SOME_FAV_DIR_ID'
       }
-      const folder = {
-        _id: 'SOME_DIR_ID'
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
       }
 
       const deleteFilePermanentlySpy = jest.fn()
@@ -519,8 +626,286 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
+      )
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID_3')
+    })
+    it('should not delete app present in computedShortcuts.infosShortcuts', async () => {
+      const foundShortcuts = [
+        {
+          _id: 'SOME_ID',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE'
+          }
+        },
+        {
+          _id: 'SOME_ID_2',
+          dir_id: 'SOME_FAV_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_2'
+          }
+        },
+        {
+          _id: 'SOME_ID_3',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_3'
+          }
+        }
+      ]
+      const computedShortcuts = {
+        schoolShortcuts: [
+          {
+            vendorRef: 'SOME_OTHER_VALUE',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
+            }
+          }
+        ],
+        favShortcuts: [],
+        infosShortcuts: [
+          {
+            vendorRef: 'SOME_VALUE_2',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: true
+                }
+              }
+            }
+          }
+        ],
+        spacesShortcuts: [],
+        persoShortcuts: []
+      }
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
+        _id: 'SOME_FAV_DIR_ID'
+      }
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
+      }
+
+      const deleteFilePermanentlySpy = jest.fn()
+      cozyUtils.client.collection = jest.fn(() => ({
+        deleteFilePermanently: deleteFilePermanentlySpy
+      }))
+
+      await cozyUtils.synchronizeShortcuts(
+        foundShortcuts,
+        computedShortcuts,
+        folders
+      )
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID_3')
+    })
+    it('should not delete app present in computedShortcuts.spacesShortcuts', async () => {
+      const foundShortcuts = [
+        {
+          _id: 'SOME_ID',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE'
+          }
+        },
+        {
+          _id: 'SOME_ID_2',
+          dir_id: 'SOME_FAV_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_2'
+          }
+        },
+        {
+          _id: 'SOME_ID_3',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_3'
+          }
+        }
+      ]
+      const computedShortcuts = {
+        schoolShortcuts: [
+          {
+            vendorRef: 'SOME_OTHER_VALUE',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
+            }
+          }
+        ],
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [
+          {
+            vendorRef: 'SOME_VALUE_2',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: true
+                }
+              }
+            }
+          }
+        ],
+        persoShortcuts: []
+      }
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
+        _id: 'SOME_FAV_DIR_ID'
+      }
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
+      }
+
+      const deleteFilePermanentlySpy = jest.fn()
+      cozyUtils.client.collection = jest.fn(() => ({
+        deleteFilePermanently: deleteFilePermanentlySpy
+      }))
+
+      await cozyUtils.synchronizeShortcuts(
+        foundShortcuts,
+        computedShortcuts,
+        folders
+      )
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
+      expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID_3')
+    })
+    it('should not delete app present in computedShortcuts.persoShortcuts', async () => {
+      const foundShortcuts = [
+        {
+          _id: 'SOME_ID',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE'
+          }
+        },
+        {
+          _id: 'SOME_ID_2',
+          dir_id: 'SOME_FAV_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_2'
+          }
+        },
+        {
+          _id: 'SOME_ID_3',
+          dir_id: 'SOME_DIR_ID',
+          type: 'file',
+          metadata: {
+            fileIdAttributes: 'SOME_VALUE_3'
+          }
+        }
+      ]
+      const computedShortcuts = {
+        schoolShortcuts: [
+          {
+            vendorRef: 'SOME_OTHER_VALUE',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
+            }
+          }
+        ],
+        favShortcuts: [],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: [
+          {
+            vendorRef: 'SOME_VALUE_2',
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: true
+                }
+              }
+            }
+          }
+        ]
+      }
+      const destinationStoreFolder = {
+        _id: 'SOME_DIR_ID'
+      }
+      const destinationFavFolder = {
+        _id: 'SOME_FAV_DIR_ID'
+      }
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
+      }
+
+      const deleteFilePermanentlySpy = jest.fn()
+      cozyUtils.client.collection = jest.fn(() => ({
+        deleteFilePermanently: deleteFilePermanentlySpy
+      }))
+
+      await cozyUtils.synchronizeShortcuts(
+        foundShortcuts,
+        computedShortcuts,
+        folders
       )
       expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
       expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID')
@@ -557,33 +942,63 @@ describe('CozyUtils', () => {
         schoolShortcuts: [
           {
             vendorRef: 'SOME_VALUE_2',
-            hubMetadata: {
-              favori: false
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
             }
           },
           {
             vendorRef: 'SOME_VALUE_3',
-            hubMetadata: {
-              favori: false
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: false
+                }
+              }
             }
           }
         ],
         favShortcuts: [
           {
             vendorRef: 'SOME_VALUE',
-            hubMetadata: {
-              favori: true
+            fileAttributes: {
+              metadata: {
+                hubMetadata: {
+                  favori: true
+                }
+              }
             }
           }
-        ]
+        ],
+        infosShortcuts: [],
+        spacesShortcuts: [],
+        persoShortcuts: []
       }
-      const favFolder = {
-        _id: 'SOME_FAV_DIR_ID'
-      }
-      const folder = {
+      const destinationStoreFolder = {
         _id: 'SOME_DIR_ID'
       }
-
+      const destinationFavFolder = {
+        _id: 'SOME_FAV_DIR_ID'
+      }
+      const destinationSpacesFolder = {
+        _id: 'SOME_SPACE_DIR_ID'
+      }
+      const destinationInfoFolder = {
+        _id: 'SOME_INFO_DIR_ID'
+      }
+      const destinationPersoFolder = {
+        _id: 'SOME_PERSO_DIR_ID'
+      }
+      const folders = {
+        destinationStoreFolder,
+        destinationFavFolder,
+        destinationSpacesFolder,
+        destinationInfoFolder,
+        destinationPersoFolder
+      }
       const deleteFilePermanentlySpy = jest.fn()
       cozyUtils.client.collection = jest.fn(() => ({
         deleteFilePermanently: deleteFilePermanentlySpy
@@ -592,8 +1007,7 @@ describe('CozyUtils', () => {
       await cozyUtils.synchronizeShortcuts(
         foundShortcuts,
         computedShortcuts,
-        folder,
-        favFolder
+        folders
       )
       expect(deleteFilePermanentlySpy).toHaveBeenCalledTimes(2)
       expect(deleteFilePermanentlySpy).toHaveBeenCalledWith('SOME_ID_2')

--- a/src/helpers/formattingShortcutsDatas.js
+++ b/src/helpers/formattingShortcutsDatas.js
@@ -4,7 +4,8 @@ function formattingShortcutsDatas(apps) {
   log('info', 'formattingShortcutsDatas starts')
   let files = []
   // keeping all commented lines around for test/debug purposes while in beta
-  // let typeValues = ['app', 'info', 'espace', 'perso']
+  // let rightsValue = ['Toutatice', 'ENT', 'GAR', 'Arena', 'ContentStore']
+  // let typeValues = ['lien', 'info', 'triskell', 'perso']
   // let index = 0
   try {
     for (const app of apps) {
@@ -19,6 +20,7 @@ function formattingShortcutsDatas(apps) {
         url: app.source,
         icon: app.vignette,
         source: app.rights,
+        // source: rightsValue[index % rightsValue.length],
         networkAccess: app.networkAccessibility,
         hubMetadata: app.hubMetadata,
         type: app.type

--- a/src/helpers/formattingShortcutsDatas.js
+++ b/src/helpers/formattingShortcutsDatas.js
@@ -3,8 +3,16 @@ const { log } = require('cozy-konnector-libs')
 function formattingShortcutsDatas(apps) {
   log('info', 'formattingShortcutsDatas starts')
   let files = []
+  // keeping all commented lines around for test/debug purposes while in beta
+  // let typeValues = ['app', 'info', 'espace', 'perso']
+  // let index = 0
   try {
     for (const app of apps) {
+      // if (index > 24) {
+      //   app.hubMetadata.favori = false
+      // } else {
+      //   app.hubMetadata.favori = true
+      // }
       files.push({
         title: app.title[0],
         description: app.description,
@@ -12,8 +20,11 @@ function formattingShortcutsDatas(apps) {
         icon: app.vignette,
         source: app.rights,
         networkAccess: app.networkAccessibility,
-        hubMetadata: app.hubMetadata
+        hubMetadata: app.hubMetadata,
+        type: app.type
+        // type: typeValues[index % typeValues.length]
       })
+      // index++
     }
     return files
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ async function start(fields) {
     log('info', 'Creating shortcuts for school apps')
     // For both of the following saveFiles we force validateFile to true
     // in order to avoid "BAD_MIME_TYPE" error while saving the shortcuts
-    await this.saveFiles(
+    const savedSchoolShortcuts = await this.saveFiles(
       computedShortcuts.schoolShortcuts,
       { folderPath: destinationFolderPath },
       {
@@ -136,7 +136,7 @@ async function start(fields) {
       }
     )
     log('info', 'Creating shortcuts for favourite apps')
-    await this.saveFiles(
+    const savedFavoriteShortcuts = await this.saveFiles(
       computedShortcuts.favShortcuts,
       { folderPath: favFolderPath },
       {
@@ -147,6 +147,10 @@ async function start(fields) {
         validateFile: () => true
       }
     )
+
+    const savedShortcuts = [...savedSchoolShortcuts, ...savedFavoriteShortcuts]
+    log('info', 'Find or creat home settings doctype')
+    await cozyUtils.findOrCreateHomeSettingsDoctype(savedShortcuts)
 
     log('info', 'Finished!')
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -110,29 +110,37 @@ async function start(fields) {
     const files = formattingShortcutsDatas(foundApps)
     const foundShortcuts = await cozyUtils.findShortcuts()
     const destinationFolderPath = '/Settings/Home'
-    const favFolderPath = `${destinationFolderPath}/⭐️ Mes favoris Toutatice`
-    const destinationFolder = await mkdirp(destinationFolderPath)
+    const favFolderPath = `${destinationFolderPath}/Applications Toutatice`
+    const infosFolderPath = `${destinationFolderPath}/Info`
+    const spacesFolderPath = `${destinationFolderPath}/Espaces`
+    const persoFolderPath = `${destinationFolderPath}/Mes liens et raccourcis`
+    const storeFolderPath = `${favFolderPath}/Store Toutatice`
+    await mkdirp(destinationFolderPath)
     const destinationFavFolder = await mkdirp(favFolderPath)
+    const destinationStoreFolder = await mkdirp(storeFolderPath)
+    const destinationInfoFolder = await mkdirp(infosFolderPath)
+    const destinationSpacesFolder = await mkdirp(spacesFolderPath)
+    const destinationPersoFolder = await mkdirp(persoFolderPath)
     const computedShortcuts = await cozyUtils.computeShortcuts(files)
-    await cozyUtils.synchronizeShortcuts(
-      foundShortcuts,
-      computedShortcuts,
-      destinationFolder,
-      destinationFavFolder
-    )
+    await cozyUtils.synchronizeShortcuts(foundShortcuts, computedShortcuts, {
+      destinationFavFolder,
+      destinationStoreFolder,
+      destinationInfoFolder,
+      destinationPersoFolder,
+      destinationSpacesFolder
+    })
     log('info', 'Creating shortcuts for school apps')
     // For both of the following saveFiles we force validateFile to true
     // in order to avoid "BAD_MIME_TYPE" error while saving the shortcuts
     const savedSchoolShortcuts = await this.saveFiles(
       computedShortcuts.schoolShortcuts,
-      { folderPath: destinationFolderPath },
+      { folderPath: storeFolderPath },
       {
         identifier: ['shortcuts'],
         sourceAccount: 'Toutatice',
         sourceAccountIdentifier: 'Toutatice',
         fileIdAttributes: ['vendorRef'],
-        validateFile: () => true,
-        subPath: '/Mes applications Toutatice'
+        validateFile: () => true
       }
     )
     log('info', 'Creating shortcuts for favourite apps')
@@ -147,8 +155,50 @@ async function start(fields) {
         validateFile: () => true
       }
     )
+    log('info', 'Creating infos shortcuts')
+    const savedInfosShortcuts = await this.saveFiles(
+      computedShortcuts.infosShortcuts,
+      { folderPath: infosFolderPath },
+      {
+        identifier: ['shortcuts'],
+        sourceAccount: 'Toutatice',
+        sourceAccountIdentifier: 'Toutatice',
+        fileIdAttributes: ['vendorRef'],
+        validateFile: () => true
+      }
+    )
+    log('info', 'Creating spaces shortcuts')
+    const savedSpacesShortcuts = await this.saveFiles(
+      computedShortcuts.spacesShortcuts,
+      { folderPath: spacesFolderPath },
+      {
+        identifier: ['shortcuts'],
+        sourceAccount: 'Toutatice',
+        sourceAccountIdentifier: 'Toutatice',
+        fileIdAttributes: ['vendorRef'],
+        validateFile: () => true
+      }
+    )
+    log('info', 'Creating personnal shortcuts')
+    const savedPersoShortcuts = await this.saveFiles(
+      computedShortcuts.persoShortcuts,
+      { folderPath: persoFolderPath },
+      {
+        identifier: ['shortcuts'],
+        sourceAccount: 'Toutatice',
+        sourceAccountIdentifier: 'Toutatice',
+        fileIdAttributes: ['vendorRef'],
+        validateFile: () => true
+      }
+    )
 
-    const savedShortcuts = [...savedSchoolShortcuts, ...savedFavoriteShortcuts]
+    const savedShortcuts = [
+      ...savedSchoolShortcuts,
+      ...savedFavoriteShortcuts,
+      ...savedInfosShortcuts,
+      ...savedSpacesShortcuts,
+      ...savedPersoShortcuts
+    ]
     log('info', 'Find or creat home settings doctype')
     await cozyUtils.findOrCreateHomeSettingsDoctype(savedShortcuts)
 


### PR DESCRIPTION
This PR remove the contact category in the manifest to avoid displaying toutatice in both categories in the store.
It also add the creation of a io.cozy.home.settings doctype for further frontend evolutions.