### PR TITLE
[SCR-842] feat: Reorganize shortcuts metadata structure

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -173,7 +173,19 @@ class CozyUtils {
           shouldReplaceFile: () => true,
           fileAttributes: {
             metadata: {
-              ...file
+              target: {
+                title: file.title,
+                description: file.description,
+                category: file.type
+              },
+              externalDataSource: {
+                networkAccess: file.networkAccess,
+                source: file.source,
+                hubMetadata: {
+                  ...file.hubMetadata
+                }
+              },
+              icon: file.icon
             }
           }
         }
@@ -214,7 +226,19 @@ class CozyUtils {
           shouldReplaceFile: () => true,
           fileAttributes: {
             metadata: {
-              ...file
+              target: {
+                title: file.title,
+                description: file.description,
+                category: file.type
+              },
+              externalDataSource: {
+                networkAccess: file.networkAccess,
+                source: file.source,
+                hubMetadata: {
+                  ...file.hubMetadata
+                }
+              },
+              icon: file.icon
             }
           }
         }
@@ -238,7 +262,7 @@ class CozyUtils {
       }
     }
     for (const app of rightContentStore) {
-      switch (app.fileAttributes.metadata.type) {
+      switch (app.fileAttributes.metadata.target.category) {
         case 'info':
           log('info', 'Info shortcut')
           infosShortcuts.push(app)
@@ -306,8 +330,8 @@ class CozyUtils {
       let idx = allComputedShortcuts.findIndex(apiShortcut => {
         return (
           apiShortcut.vendorRef === cozyShortcut.metadata.fileIdAttributes &&
-          apiShortcut.fileAttributes?.metadata?.hubMetadata?.favori ===
-            isFavourite
+          apiShortcut.fileAttributes?.metadata?.externalDataSource?.hubMetadata
+            ?.favori === isFavourite
         )
       })
       if (idx == -1) {

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -480,8 +480,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -490,8 +492,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -572,8 +576,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -584,8 +590,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: true
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: true
+                  }
                 }
               }
             }
@@ -665,8 +673,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -678,8 +688,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: true
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: true
+                  }
                 }
               }
             }
@@ -772,8 +784,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: true
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: true
+                  }
                 }
               }
             }
@@ -851,8 +865,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_OTHER_VALUE',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -866,8 +882,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: true
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: true
+                  }
                 }
               }
             }
@@ -944,8 +962,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_2',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -954,8 +974,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE_3',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: false
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: false
+                  }
                 }
               }
             }
@@ -966,8 +988,10 @@ describe('CozyUtils', () => {
             vendorRef: 'SOME_VALUE',
             fileAttributes: {
               metadata: {
-                hubMetadata: {
-                  favori: true
+                externalDataSource: {
+                  hubMetadata: {
+                    favori: true
+                  }
                 }
               }
             }


### PR DESCRIPTION
This PR review the structure of the shortcuts metadata, allowing better understanding on what's coming from toutatice API and how is it saved in cozy.
It also remove useless `url` data saved in the last version as it is only used for the shortcut file creation, no need to keep it in the metadata.

TUs adaptation ~~incoming~~ done  ✅  