### PR TITLE
fix: Move description attribute

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -175,7 +175,6 @@ class CozyUtils {
             metadata: {
               target: {
                 title: file.title,
-                description: file.description,
                 category: file.type
               },
               externalDataSource: {
@@ -185,6 +184,7 @@ class CozyUtils {
                   ...file.hubMetadata
                 }
               },
+              description: file.description,
               icon: file.icon
             }
           }
@@ -228,7 +228,6 @@ class CozyUtils {
             metadata: {
               target: {
                 title: file.title,
-                description: file.description,
                 category: file.type
               },
               externalDataSource: {
@@ -238,6 +237,7 @@ class CozyUtils {
                   ...file.hubMetadata
                 }
               },
+              description: file.description,
               icon: file.icon
             }
           }


### PR DESCRIPTION
We introduced the `metadata.target.description`, but it appears that we already have shortcuts using `metadata.description`, so let's use it.