### PR TITLE
feat: map invalid OAuth refresh token to USER_ACTION_NEEDED_OAUTH_OUTDATED

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -1,4 +1,4 @@
-const { log } = require('cozy-konnector-libs')
+const { log, errors } = require('cozy-konnector-libs')
 const get = require('lodash/get')
 const initCozyClient = require('./helpers/initCozyClient')
 
@@ -15,12 +15,23 @@ class CozyUtils {
   }
 
   async refreshToken(accountId) {
-    const response = await this.client.fetch(
-      'POST',
-      `/accounts/toutatice/${accountId}/refresh`
-    )
-    const body = await response.json()
-    return get(body, 'data.attributes.oauth.access_token', null)
+    try {
+      const response = await this.client.fetch(
+        'POST',
+        `/accounts/toutatice/${accountId}/refresh`
+      )
+      const body = await response.json()
+      return get(body, 'data.attributes.oauth.access_token', null)
+    } catch (err) {
+      if (get(err, 'reason.errors[0].code') === 'oauth_refresh_invalid_token') {
+        log(
+          'warn',
+          'OAuth refresh token is invalid or expired, account reconnection is required.'
+        )
+        throw errors.USER_ACTION_NEEDED_OAUTH_OUTDATED
+      }
+      throw err
+    }
   }
 
   async prepareIndexes(contactAccountId) {

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -1,7 +1,13 @@
 jest.mock('cozy-client')
-jest.mock('cozy-konnector-libs')
+jest.mock('cozy-konnector-libs', () => ({
+  log: jest.fn(),
+  errors: {
+    USER_ACTION_NEEDED_OAUTH_OUTDATED: new Error('USER_ACTION_NEEDED.OAUTH_OUTDATED')
+  }
+}))
 
 const CozyClient = require('cozy-client').default
+const { errors } = require('cozy-konnector-libs')
 const CozyUtils = require('./CozyUtils')
 
 const {
@@ -76,6 +82,30 @@ describe('CozyUtils', () => {
       cozyUtils.client.fetch = jest.fn(() => ({ json: () => null }))
       const result = await cozyUtils.refreshToken('123')
       expect(result).toEqual(null)
+    })
+
+    it('should throw OAUTH_OUTDATED when stack returns oauth_refresh_invalid_token', async () => {
+      const stackError = {
+        reason: {
+          errors: [{ code: 'oauth_refresh_invalid_token' }]
+        }
+      }
+      cozyUtils.client.fetch = jest.fn(async () => {
+        throw stackError
+      })
+
+      await expect(cozyUtils.refreshToken('123')).rejects.toBe(
+        errors.USER_ACTION_NEEDED_OAUTH_OUTDATED
+      )
+    })
+
+    it('should rethrow unknown refresh errors', async () => {
+      const unexpectedError = new Error('Something failed')
+      cozyUtils.client.fetch = jest.fn(async () => {
+        throw unexpectedError
+      })
+
+      await expect(cozyUtils.refreshToken('123')).rejects.toBe(unexpectedError)
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,11 @@ async function start(fields) {
   } catch (err) {
     log('error', 'caught an unexpected error')
     log('error', err.message)
+    if (
+      err === errors.USER_ACTION_NEEDED_OAUTH_OUTDATED
+    ) {
+      throw err
+    }
     throw errors.VENDOR_DOWN
   }
 }


### PR DESCRIPTION
  Description:
  /accounts/:accountType/:accountId/refresh can fail with stack code oauth_refresh_invalid_token (refresh token invalid/expired).
  Before this change, the connector ended up returning a generic VENDOR_DOWN, so Home could not show the correct reconnect flow.

  Expected result:

  - Home receives USER_ACTION_NEEDED.OAUTH_OUTDATED
  - user sees the proper “access refresh required / reconnect account” message instead of vendor-down