### PR TITLE
fix: force refresh call to throw on HTTP errors

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -18,7 +18,9 @@ class CozyUtils {
     try {
       const response = await this.client.fetch(
         'POST',
-        `/accounts/toutatice/${accountId}/refresh`
+        `/accounts/toutatice/${accountId}/refresh`,
+        null,
+        { throwFetchErrors: true }
       )
       const body = await response.json()
       return get(body, 'data.attributes.oauth.access_token', null)

--- a/src/cozyUtils.spec.js
+++ b/src/cozyUtils.spec.js
@@ -73,7 +73,9 @@ describe('CozyUtils', () => {
       const result = await cozyUtils.refreshToken(MOCK_ACCOUNT_ID)
       expect(cozyUtils.client.fetch).toHaveBeenCalledWith(
         'POST',
-        '/accounts/toutatice/123/refresh'
+        '/accounts/toutatice/123/refresh',
+        null,
+        { throwFetchErrors: true }
       )
       expect(result).toEqual(MOCK_REFRESHED_TOKEN)
     })


### PR DESCRIPTION
## Context

  `CozyUtils.refreshToken()` was calling `client.fetch()` without `throwFetchErrors`.
  Because of that, HTTP errors from `/accounts/toutatice/:accountId/refresh` (like 401) were not always thrown.
